### PR TITLE
Implement basic ZMQ notifications for moves in attached/detached blocks

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -204,6 +204,7 @@ BITCOIN_CORE_H = \
   warnings.h \
   zmq/zmqabstractnotifier.h \
   zmq/zmqconfig.h\
+  zmq/zmqgames.h \
   zmq/zmqnotificationinterface.h \
   zmq/zmqpublishnotifier.h \
   zmq/zmqrpc.h
@@ -270,6 +271,7 @@ libbitcoin_zmq_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(ZMQ_CFLAGS)
 libbitcoin_zmq_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_zmq_a_SOURCES = \
   zmq/zmqabstractnotifier.cpp \
+  zmq/zmqgames.cpp \
   zmq/zmqnotificationinterface.cpp \
   zmq/zmqpublishnotifier.cpp \
   zmq/zmqrpc.cpp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -448,11 +448,15 @@ void SetupServerArgs()
     gArgs.AddArg("-zmqpubhashtx=<address>", "Enable publish hash transaction in <address>", false, OptionsCategory::ZMQ);
     gArgs.AddArg("-zmqpubrawblock=<address>", "Enable publish raw block in <address>", false, OptionsCategory::ZMQ);
     gArgs.AddArg("-zmqpubrawtx=<address>", "Enable publish raw transaction in <address>", false, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubgameblocks=<address>", "Enable publication of game data for block attach/detach events in <address>", false, OptionsCategory::ZMQ);
+    gArgs.AddArg("-trackgame=<game>", "Enable tracking of the listed game for the Xaya game interface", false, OptionsCategory::ZMQ);
 #else
     hidden_args.emplace_back("-zmqpubhashblock=<address>");
     hidden_args.emplace_back("-zmqpubhashtx=<address>");
     hidden_args.emplace_back("-zmqpubrawblock=<address>");
     hidden_args.emplace_back("-zmqpubrawtx=<address>");
+    hidden_args.emplace_back("-zmqpubgameblocks=<address>");
+    hidden_args.emplace_back("-trackgame=<game>");
 #endif
 
     gArgs.AddArg("-checkblocks=<n>", strprintf("How many blocks to check at startup (default: %u, 0 = all)", DEFAULT_CHECKBLOCKS), true, OptionsCategory::DEBUG_TEST);

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -20,3 +20,13 @@ bool CZMQAbstractNotifier::NotifyTransaction(const CTransaction &/*transaction*/
 {
     return true;
 }
+
+bool CZMQAbstractNotifier::NotifyBlockAttached(const CBlock& /*block*/, const CBlockIndex* /*pindex*/)
+{
+    return true;
+}
+
+bool CZMQAbstractNotifier::NotifyBlockDetached(const CBlock& /*block*/, const CBlockIndex* /*pindex*/)
+{
+    return true;
+}

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -35,6 +35,11 @@ public:
     virtual bool NotifyBlock(const CBlockIndex *pindex);
     virtual bool NotifyTransaction(const CTransaction &transaction);
 
+    /* Block attach and detach notifications are used for the game
+       interface in Xaya.  */
+    virtual bool NotifyBlockAttached(const CBlock& block, const CBlockIndex* pindex);
+    virtual bool NotifyBlockDetached(const CBlock& block, const CBlockIndex* pindex);
+
 protected:
     void *psocket;
     std::string type;

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -7,10 +7,12 @@
 
 #include <zmq/zmqconfig.h>
 
+#include <functional>
+
 class CBlockIndex;
 class CZMQAbstractNotifier;
 
-typedef CZMQAbstractNotifier* (*CZMQNotifierFactory)();
+using CZMQNotifierFactory = std::function<CZMQAbstractNotifier*()>;
 
 class CZMQAbstractNotifier
 {

--- a/src/zmq/zmqgames.cpp
+++ b/src/zmq/zmqgames.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2018 The Xaya developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#include <zmq/zmqgames.h>
+
+#include <amount.h>
+#include <chain.h>
+#include <core_io.h>
+#include <key_io.h>
+#include <logging.h>
+#include <names/common.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <script/names.h>
+#include <script/standard.h>
+
+#include <univalue.h>
+
+#include <map>
+
+bool
+ZMQGameBlocksNotifier::SendMessage (const std::string& command,
+                                    const UniValue& data)
+{
+  const std::string dataStr = data.write ();
+  return CZMQAbstractPublishNotifier::SendMessage (
+      command.c_str (), dataStr.c_str (), dataStr.size ());
+}
+
+namespace
+{
+
+/**
+ * Converts a transaction to the corresponding JSON data that is returned
+ * for it in the Xaya game interface.  The returned map contains the data
+ * for each of the games that may be referenced (and are tracked).  If the
+ * transaction is not a name operation, then the empty map is returned.
+ */
+std::map<std::string, UniValue>
+JsonDataForMove (const CTransaction& tx)
+{
+  /* Determine if this is a name update at all; if it isn't, then there
+     is nothing to do for this transaction.  */
+  CNameScript nameOp;
+  for (const auto& out : tx.vout)
+    {
+      nameOp = CNameScript (out.scriptPubKey);
+      if (nameOp.isNameOp ())
+        break;
+    }
+  if (!nameOp.isNameOp () || !nameOp.isAnyUpdate ())
+    return {};
+
+  /* Only consider updates to p/ names.  */
+  const std::string name = ValtypeToString (nameOp.getOpName ());
+  if (name.substr (0, 2) != "p/")
+    return {};
+
+  /* See if there are actually games mentioned in the update's value.  */
+  const std::string valueStr = ValtypeToString (nameOp.getOpValue ());
+  UniValue value;
+  if (!value.read (valueStr) || !value.isObject ())
+    {
+      /* This shouldn't actually happen, as the consensus rules check for
+         these conditions for name updates.  But if it does happen, we just
+         ignore it for here.  */
+      LogPrintf ("%s: invalid value ignored\n", __func__);
+      return {};
+    }
+  if (!value.exists ("g"))
+    return {};
+  const UniValue& g = value["g"];
+  if (!g.isObject () || g.empty ())
+    return {};
+
+  /* Prepare a template object that is the same for all games.  */
+  UniValue tmpl(UniValue::VOBJ);
+  tmpl.pushKV ("txid", tx.GetHash ().GetHex ());
+  tmpl.pushKV ("name", name.substr (2));
+
+  std::map<std::string, CAmount> outAmounts;
+  for (const auto& out : tx.vout)
+    {
+      const CNameScript nameOp(out.scriptPubKey);
+      if (nameOp.isNameOp ())
+        continue;
+
+      CTxDestination dest;
+      if (!ExtractDestination (out.scriptPubKey, dest))
+        continue;
+
+      const std::string addr = EncodeDestination (dest);
+      outAmounts[addr] += out.nValue;
+    }
+
+  UniValue out(UniValue::VOBJ);
+  for (const auto& entry : outAmounts)
+    out.pushKV (entry.first, ValueFromAmount (entry.second));
+  tmpl.pushKV ("out", out);
+
+  /* Fill the per-game moves into the template.  */
+  std::map<std::string, UniValue> result;
+  for (const auto& game : g.getKeys ())
+    {
+      UniValue obj = tmpl;
+      obj.pushKV ("move", g[game]);
+      result[game] = obj;
+    }
+
+  return result;
+}
+
+} // anonymous namespace
+
+bool
+ZMQGameBlocksNotifier::SendBlockNotifications (const std::string& commandPrefix,
+                                               const CBlock& block,
+                                               const CBlockIndex* pindex)
+{
+  /* Start with an empty array of moves for each game that we track.  */
+  std::map<std::string, UniValue> perGameMoves;
+  for (const auto& game : trackedGames)
+    perGameMoves[game] = UniValue (UniValue::VARR);
+
+  /* Add relevant moves for each game from all the transactions.  */
+  for (const auto& tx : block.vtx)
+    {
+      const auto perGameThisTx = JsonDataForMove (*tx);
+      for (const auto& entry : perGameThisTx)
+        {
+          auto mit = perGameMoves.find (entry.first);
+          if (mit == perGameMoves.end ())
+            continue;
+
+          assert (trackedGames.count (entry.first) > 0);
+          assert (mit->second.isArray ());
+          mit->second.push_back (entry.second);
+        }
+    }
+
+  /* Prepare the template object that is the same for each game.  */
+  UniValue tmpl(UniValue::VOBJ);
+  if (pindex->nHeight > 0)
+    {
+      assert (pindex->pprev != nullptr);
+      tmpl.pushKV ("parent", pindex->pprev->GetBlockHash ().GetHex ());
+    }
+  tmpl.pushKV ("child", block.GetHash ().GetHex ());
+
+  /* Send notifications for all games with the moves merged into the
+     template object.  */
+  for (const auto& game : trackedGames)
+    {
+      auto mit = perGameMoves.find (game);
+      assert (mit != perGameMoves.end ());
+      assert (mit->second.isArray ());
+
+      UniValue data = tmpl;
+      data.pushKV ("moves", mit->second);
+      if (!SendMessage (commandPrefix + " json " + game, data))
+        return false;
+    }
+
+  return true;
+}
+
+bool
+ZMQGameBlocksNotifier::NotifyBlockAttached (const CBlock& block,
+                                            const CBlockIndex* pindex)
+{
+  return SendBlockNotifications ("game-block-attach", block, pindex);
+}
+
+bool
+ZMQGameBlocksNotifier::NotifyBlockDetached (const CBlock& block,
+                                            const CBlockIndex* pindex)
+{
+  return SendBlockNotifications ("game-block-detach", block, pindex);
+}

--- a/src/zmq/zmqgames.h
+++ b/src/zmq/zmqgames.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2018 The Xaya developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_ZMQ_ZMQGAMES_H
+#define BITCOIN_ZMQ_ZMQGAMES_H
+
+#include <zmq/zmqpublishnotifier.h>
+
+#include <set>
+#include <string>
+
+class CBlock;
+class CBlockIndex;
+class UniValue;
+
+/**
+ * ZMQ publisher that handles the attach/detach messages for the Xaya game
+ * interface (https://github.com/xaya/Specs/blob/master/interface.md).
+ */
+class ZMQGameBlocksNotifier : public CZMQAbstractPublishNotifier
+{
+
+private:
+
+  /** The set of games tracked by this notifier.  */
+  std::set<std::string> trackedGames;
+
+  /**
+   * Sends a multipart message where the payload data is JSON.
+   */
+  bool SendMessage (const std::string& command, const UniValue& data);
+
+  /**
+   * Sends the block attach or detach notifications.  They are essentially the
+   * same, except that they have a different command string.
+   */
+  bool SendBlockNotifications (const std::string& commandPrefix,
+                               const CBlock& block, const CBlockIndex* pindex);
+
+public:
+
+  ZMQGameBlocksNotifier () = delete;
+
+  explicit ZMQGameBlocksNotifier (const std::set<std::string>& games)
+    : trackedGames(games)
+  {}
+
+  bool NotifyBlockAttached (const CBlock& block,
+                            const CBlockIndex* pindex) override;
+  bool NotifyBlockDetached (const CBlock& block,
+                            const CBlockIndex* pindex) override;
+
+};
+
+#endif // BITCOIN_ZMQ_ZMQGAMES_H

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -3,6 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <zmq/zmqnotificationinterface.h>
+
+#include <zmq/zmqgames.h>
 #include <zmq/zmqpublishnotifier.h>
 
 #include <version.h>
@@ -48,6 +50,12 @@ CZMQNotificationInterface* CZMQNotificationInterface::Create()
     factories["pubhashtx"] = CZMQAbstractNotifier::Create<CZMQPublishHashTransactionNotifier>;
     factories["pubrawblock"] = CZMQAbstractNotifier::Create<CZMQPublishRawBlockNotifier>;
     factories["pubrawtx"] = CZMQAbstractNotifier::Create<CZMQPublishRawTransactionNotifier>;
+
+    const std::vector<std::string> vTrackedGames = gArgs.GetArgs("-trackgame");
+    const std::set<std::string> trackedGames(vTrackedGames.begin(), vTrackedGames.end());
+    factories["pubgameblocks"] = [&trackedGames]() {
+        return new ZMQGameBlocksNotifier(trackedGames);
+    };
 
     for (const auto& entry : factories)
     {

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -135,13 +135,13 @@ bool CZMQAbstractPublishNotifier::SendMessage(const char *command, const void* d
 
     /* send three parts, command & data & a LE 4byte sequence number */
     unsigned char msgseq[sizeof(uint32_t)];
-    WriteLE32(&msgseq[0], nSequence);
+    WriteLE32(&msgseq[0], sequenceNumbers[command]);
     int rc = zmq_send_multipart(psocket, command, strlen(command), data, size, msgseq, (size_t)sizeof(uint32_t), nullptr);
     if (rc == -1)
         return false;
 
     /* increment memory only sequence number after sending */
-    nSequence++;
+    ++sequenceNumbers[command];
 
     return true;
 }

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -7,12 +7,16 @@
 
 #include <zmq/zmqabstractnotifier.h>
 
+#include <map>
+#include <string>
+
 class CBlockIndex;
 
 class CZMQAbstractPublishNotifier : public CZMQAbstractNotifier
 {
 private:
-    uint32_t nSequence; //!< upcounting per message sequence number
+    /** Upcounting sequence number of messages, per command string.  */
+    std::map<std::string, uint32_t> sequenceNumbers;
 
 public:
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -174,6 +174,7 @@ BASE_SCRIPTS = [
 
     # Xaya-specific tests
     'xaya_dualalgo.py',
+    'xaya_gameblocks.py',
     'xaya_premine.py',
 ]
 

--- a/test/functional/xaya_gameblocks.py
+++ b/test/functional/xaya_gameblocks.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test the "game-block" ZMQ notifications."""
+
+from test_framework.test_framework import (
+  BitcoinTestFramework,
+  skip_if_no_bitcoind_zmq,
+  skip_if_no_py3_zmq,
+)
+from test_framework.messages import (
+  COIN,
+  COutPoint,
+  CTransaction,
+  CTxIn,
+  CTxOut,
+)
+from test_framework.util import (
+  assert_equal,
+  bytes_to_hex_str,
+  hex_str_to_bytes,
+)
+from test_framework.script import (
+  CScript,
+  OP_TRUE,
+)
+
+from decimal import Decimal
+import codecs
+import json
+import struct
+
+
+def assertMove (obj, txid, name, move):
+  """
+  Utility method to assert the value of a move JSON without verifying
+  the "out" field (which is unpredictable due to the change output).
+  """
+
+  assert_equal (obj["txid"], txid)
+  assert_equal (obj["name"], name)
+  assert_equal (obj["move"], move)
+
+
+class GameSubscriber:
+
+  def __init__ (self, ctx, addr, game):
+    self.sequence = {}
+    self.game = game
+
+    import zmq
+    self.socket = ctx.socket (zmq.SUB)
+    self.socket.set (zmq.RCVTIMEO, 60000)
+    self.socket.connect (addr)
+    self.socket.setsockopt_string (zmq.SUBSCRIBE,
+                                   "game-block-attach json %s" % game)
+    self.socket.setsockopt_string (zmq.SUBSCRIBE,
+                                   "game-block-detach json %s" % game)
+
+  def receive (self):
+    topic, body, seq = self.socket.recv_multipart ()
+
+    topic = codecs.decode (topic, "ascii")
+    parts = topic.split (" ")
+    assert_equal (len (parts), 3)
+    assert_equal (parts[1], "json")
+    assert_equal (parts[2], self.game)
+    assert parts[0] in ["game-block-attach", "game-block-detach"]
+
+    # Sequence should be incremental for the full topic string.
+    seqNum = struct.unpack ("<I", seq)[-1]
+    if not topic in self.sequence:
+      self.sequence[topic] = 0
+    assert_equal (seqNum, self.sequence[topic])
+    self.sequence[topic] += 1
+
+    return topic, json.loads (codecs.decode (body, "ascii"))
+
+  def assertNoMessage (self):
+    import zmq
+    try:
+      _ = self.socket.recv (zmq.NOBLOCK)
+      raise AssertionError ("expected no more messages, but got one")
+    except zmq.error.Again:
+      pass
+
+
+class GameBlocksTest (BitcoinTestFramework):
+
+  _address = "tcp://127.0.0.1:28332"
+
+  def set_test_params (self):
+    self.num_nodes = 1
+
+  def setup_nodes (self):
+    skip_if_no_py3_zmq ()
+    skip_if_no_bitcoind_zmq (self)
+
+    import zmq
+    self.zmq_context = zmq.Context ()
+    self.games = {}
+    for g in ["a", "b", "ignored"]:
+      self.games[g] = GameSubscriber (self.zmq_context, self._address, g)
+
+    args = []
+    args.append ("-zmqpubgameblocks=%s" % self._address)
+    args.extend (["-trackgame=%s" % g for g in ["a", "b", "other"]])
+    self.extra_args = [args]
+    self.add_nodes (self.num_nodes, self.extra_args)
+    self.start_nodes ()
+
+    self.node = self.nodes[0]
+
+  def run_test (self):
+    try:
+      self._test_currencyIgnored ()
+      self._test_register ()
+      self._test_blockHashes ()
+      self._test_multipleUpdates ()
+      self._test_moveWithCurrency ()
+      self._test_reorg ()
+
+      # After all the real tests, verify no more notifications are there.
+      # This especially verifies that the "ignored" game we are subscribed to
+      # has no notifications (because it is not tracked by the daemon).
+      for _, sub in self.games.items ():
+        sub.assertNoMessage ()
+    finally:
+      self.log.debug ("Destroying ZMQ context")
+      self.zmq_context.destroy (linger=None)
+
+  def _test_currencyIgnored (self):
+    """
+    Tests that a currency transaction does not show up as move in the
+    notifications.
+    """
+
+    self.log.info ("Testing pure currency transaction...")
+
+    addr = self.node.getnewaddress ()
+    self.node.sendtoaddress (addr, 1.5)
+    self.node.generate (1)
+
+    for g in ["a", "b"]:
+      _, data = self.games[g].receive ()
+      assert_equal (data["moves"], [])
+
+  def _test_register (self):
+    """
+    Registers test names and verifies that this already triggers
+    a notification (not just name_update's).
+    """
+
+    self.log.info ("Registering names...")
+
+    txid = self.node.name_register ("p/x", json.dumps ({"g":{"a":42}}))
+    self.node.name_register ("p/y", json.dumps ({"g":{"other":False}}))
+    self.node.generate (1)
+
+    _, data = self.games["a"].receive ()
+    assert_equal (len (data["moves"]), 1)
+    assertMove (data["moves"][0], txid, "x", 42)
+
+    _, data = self.games["b"].receive ()
+    assert_equal (data["moves"], [])
+
+  def _test_blockHashes (self):
+    """
+    Verifies the block hashes (parent and child) in the main message that
+    is sent against the blockchain.
+    """
+
+    self.log.info ("Verifying block hashes...")
+
+    parent = self.node.getbestblockhash ()
+    child = self.node.generate (1)[0]
+    expected = {"parent": parent, "child": child, "moves": []}
+
+    for g in ["a", "b"]:
+      _, data = self.games[g].receive ()
+      assert_equal (data, expected)
+
+  def _test_multipleUpdates (self):
+    """
+    Tests the case of multiple name updates in the block and multiple
+    games referenced for a single name.
+    """
+
+    self.log.info ("Testing multiple updates in one block...")
+
+    txidX = self.node.name_update ("p/x", json.dumps ({
+      "stuff": "foo",
+      "g":
+        {
+          "a": [42, False],
+          "b": {"test": True},
+        },
+    }))
+    txidY = self.node.name_update ("p/y", json.dumps ({"g":{"b":6.25}}))
+    blk = self.node.generate (1)[0]
+
+    # Get the order of our two transactions in the block, so that we can check
+    # that the order in the notification matches it.
+    txids = self.node.getblock (blk)["tx"][1:]
+    assert_equal (set (txids), set ([txidX, txidY]))
+    indX = txids.index (txidX)
+    indY = txids.index (txidY)
+
+    _, data = self.games["a"].receive ()
+    assert_equal (len (data["moves"]), 1)
+    assertMove (data["moves"][0], txidX, "x", [42, False])
+
+    _, data = self.games["b"].receive ()
+    assert_equal (len (data["moves"]), 2)
+    assertMove (data["moves"][indX], txidX, "x", {"test": True})
+    assertMove (data["moves"][indY], txidY, "y", 6.25)
+
+  def _test_moveWithCurrency (self):
+    """
+    Sends currency to predefined addresses together with a move and checks
+    the "out" field produced by the notifications.
+    """
+
+    self.log.info ("Sending move with currency...")
+
+    addr1 = self.node.getnewaddress ()
+    addr2 = "dHNvNaqcD7XPDnoRjAoyfcMpHRi5upJD7p"
+
+    # Send a move and spend coins in the same transaction.  We use a raw
+    # transaction, so that we can actually send *two* outputs to the *same*
+    # address.  This should work, and return it only once in the notification
+    # with the total amount.  We use amounts with precision down to satoshis
+    # to check this works correctly.
+
+    hex1 = self.node.getaddressinfo (addr1)["scriptPubKey"]
+    hex2 = self.node.getaddressinfo (addr2)["scriptPubKey"]
+    scr1 = CScript (hex_str_to_bytes (hex1))
+    scr2 = CScript (hex_str_to_bytes (hex2))
+
+    tx = CTransaction ()
+    name = self.node.name_show ("p/x")
+    tx.vin.append (CTxIn (COutPoint (int (name["txid"], 16), name["vout"])))
+    tx.vout.append (CTxOut (12345678, scr1))
+    tx.vout.append (CTxOut (142424242, scr2))
+    tx.vout.append (CTxOut (COIN, scr1))
+    tx.vout.append (CTxOut (COIN // 2, CScript ([OP_TRUE])))
+    tx.vout.append (CTxOut (COIN // 100, scr1))
+    rawtx = bytes_to_hex_str (tx.serialize ())
+
+    nameOp = {
+      "op": "name_update",
+      "name": "p/x",
+      "value": json.dumps ({"g":{"a":"move"}}),
+    }
+    rawtx = self.node.namerawtransaction (rawtx, 4, nameOp)["hex"]
+
+    rawtx = self.node.fundrawtransaction (rawtx)["hex"]
+    signed = self.node.signrawtransactionwithwallet (rawtx)
+    assert signed["complete"]
+    txid = self.node.sendrawtransaction (signed["hex"])
+    self.node.generate (1)
+
+    _, data = self.games["a"].receive ()
+    assert_equal (len (data["moves"]), 1)
+    assertMove (data["moves"][0], txid, "x", "move")
+    out = data["moves"][0]["out"]
+    assert_equal (len (out), 3)
+    quant = Decimal ('1.00000000')
+    assert_equal (Decimal (out[addr1]).quantize (quant), Decimal ('1.12345678'))
+    assert_equal (Decimal (out[addr2]).quantize (quant), Decimal ('1.42424242'))
+
+    _, data = self.games["b"].receive ()
+    assert_equal (data["moves"], [])
+
+  def _test_reorg (self):
+    """
+    Produces a reorg and checks the resulting sequence of notifications
+    (including those for detached blocks).
+    """
+
+    self.log.info ("Testing reorg...")
+
+    def buildChain (n):
+      blks = []
+      attachA = []
+      attachB = []
+      for i in range (n):
+        blks.extend (self.node.generate (1))
+        topic, data = self.games["a"].receive ()
+        assert_equal (topic, "game-block-attach json a")
+        attachA.append (data)
+        topic, data = self.games["b"].receive ()
+        assert_equal (topic, "game-block-attach json b")
+        attachB.append (data)
+      return blks, attachA, attachB
+
+    def verifyDetach (attachA, attachB):
+      n = len (attachA)
+      assert_equal (len (attachB), n)
+      for i in range (n):
+        topic, data = self.games["a"].receive ()
+        assert_equal (topic, "game-block-detach json a")
+        assert_equal (data, attachA[-i - 1])
+        topic, data = self.games["b"].receive ()
+        assert_equal (topic, "game-block-detach json b")
+        assert_equal (data, attachB[-i - 1])
+
+    # Start by building a long chain that we will later reorg to.  Include a
+    # move (just because, not really important) and record the attach
+    # notifications we get.
+    self.node.name_update ("p/x", json.dumps ({"g":{"a": True}}))
+    longBlks, longAttachA, longAttachB = buildChain (10)
+
+    # Invalidate the first block, which should trigger detaches.
+    self.node.invalidateblock (longBlks[0])
+    verifyDetach (longAttachA, longAttachB)
+
+    # Build a shorter chain.
+    _, shortAttachA, shortAttachB = buildChain (5)
+
+    # Trigger the reorg and verify the notifications.
+    self.node.reconsiderblock (longBlks[0])
+    verifyDetach (shortAttachA, shortAttachB)
+    for i in range (len (longBlks)):
+      topic, data = self.games["a"].receive ()
+      assert_equal (topic, "game-block-attach json a")
+      assert_equal (data, longAttachA[i])
+      topic, data = self.games["b"].receive ()
+      assert_equal (topic, "game-block-attach json b")
+      assert_equal (data, longAttachB[i])
+
+
+if __name__ == '__main__':
+    GameBlocksTest ().main ()


### PR DESCRIPTION
This implements #51, namely the basic ZMQ notifiers for game moves in attached and detached blocks as described in our [design doc](https://github.com/xaya/Specs/blob/master/interface.md#attaching-and-detaching-publishers-).

In particular, we add a new ZMQ notifier that can be enabled with `-zmqpubgameblocks` and will then send `game-block-attach` and `game-block-detach` notifications for each attached/detached block and each tracked game.  The games that are tracked can be configured with `-trackgame` (or `trackgame=` in the `xaya.conf` file).