### PR TITLE
Implement game_sendupdates

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -156,6 +156,7 @@ BITCOIN_CORE_H = \
   rpc/auxpow_miner.h \
   rpc/blockchain.h \
   rpc/client.h \
+  rpc/game.h \
   rpc/mining.h \
   rpc/names.h \
   rpc/protocol.h \
@@ -248,6 +249,7 @@ libbitcoin_server_a_SOURCES = \
   rest.cpp \
   rpc/auxpow_miner.cpp \
   rpc/blockchain.cpp \
+  rpc/game.cpp \
   rpc/mining.cpp \
   rpc/misc.cpp \
   rpc/names.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -124,7 +124,7 @@ test_test_xaya_LDADD += $(LIBBITCOIN_CONSENSUS) $(LIBBITCOIN_CRYPTO) $(BDB_LIBS)
 test_test_xaya_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) -static
 
 if ENABLE_ZMQ
-test_test_xaya_LDADD += $(ZMQ_LIBS)
+test_test_xaya_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
 endif
 #
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -120,6 +120,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::QT, "qt"},
     {BCLog::LEVELDB, "leveldb"},
     {BCLog::NAMES, "names"},
+    {BCLog::GAME, "game"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -54,6 +54,7 @@ namespace BCLog {
         QT          = (1 << 19),
         LEVELDB     = (1 << 20),
         NAMES       = (1 << 21),
+        GAME        = (1 << 22),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/rpc/game.cpp
+++ b/src/rpc/game.cpp
@@ -1,0 +1,304 @@
+// Copyright (c) 2018 The Xaya developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <rpc/game.h>
+
+#include <chain.h>
+#include <chainparams.h>
+#include <logging.h>
+#include <rpc/server.h>
+#include <script/script.h>
+#include <uint256.h>
+#include <util.h>
+#include <validation.h>
+#include <zmq/zmqgames.h>
+#include <zmq/zmqnotificationinterface.h>
+
+#include <univalue.h>
+
+#include <sstream>
+
+/* ************************************************************************** */
+
+std::string
+SendUpdatesWorker::Work::str () const
+{
+  std::ostringstream res;
+
+  res << "work(";
+
+  res << "games: ";
+  bool first = true;
+  for (const auto& g : trackedGames)
+    {
+      if (!first)
+        res << "|";
+      first = false;
+      res << g;
+    }
+  res << ", ";
+
+  res << detach.size () << " detaches, "
+      << attach.size () << " attaches";
+  res << ")";
+
+  return res.str ();
+}
+
+SendUpdatesWorker::SendUpdatesWorker ()
+  : interrupted(false)
+{
+  runner.reset (new std::thread ([this] ()
+    {
+      TraceThread ("sendupdates", [this] () { run (*this); });
+    }));
+}
+
+SendUpdatesWorker::~SendUpdatesWorker ()
+{
+  if (runner != nullptr && runner->joinable ())
+    runner->join ();
+  runner.reset ();
+}
+
+namespace
+{
+
+#if ENABLE_ZMQ
+void
+SendUpdatesOneBlock (const std::set<std::string>& trackedGames,
+                     const std::string& commandPrefix,
+                     const CBlockIndex* pindex)
+{
+  CBlock blk;
+  if (!ReadBlockFromDisk (blk, pindex, Params ().GetConsensus ()))
+    {
+      LogPrint (BCLog::GAME, "Reading block %s failed, ignoring\n",
+                pindex->GetBlockHash ().GetHex ());
+      return;
+    }
+
+  /* These two conditions are checked before enqueueing work.  So if we make
+     it here, we know that there must be a games notifier.  */
+  assert (g_zmq_notification_interface != nullptr);
+  auto* notifier = g_zmq_notification_interface->GetGameBlocksNotifier ();
+  assert (notifier != nullptr);
+
+  notifier->SendBlockNotifications (trackedGames, commandPrefix, blk, pindex);
+}
+#endif // ENABLE_ZMQ
+
+} // anonymous namespace
+
+void
+SendUpdatesWorker::run (SendUpdatesWorker& self)
+{
+#if ENABLE_ZMQ
+  while (true)
+    {
+      Work w;
+
+      {
+        WaitableLock lock(self.csWork);
+
+        if (self.work.empty ())
+          {
+            LogPrint (BCLog::GAME,
+                      "SendUpdatesWorker queue empty, interrupted = %d\n",
+                      self.interrupted);
+
+            if (self.interrupted)
+              break;
+
+            LogPrint (BCLog::GAME,
+                      "Waiting for sendupdates condition variable...\n");
+            self.cvWork.wait (lock);
+            continue;
+          }
+
+        w = std::move (self.work.front ());
+        self.work.pop ();
+
+        LogPrint (BCLog::GAME, "Popped for sendupdates processing: %s\n",
+                  w.str ().c_str ());
+      }
+
+      for (const auto* pindex : w.detach)
+        SendUpdatesOneBlock (w.trackedGames,
+                             ZMQGameBlocksNotifier::PREFIX_DETACH, pindex);
+      for (const auto* pindex : w.attach)
+        SendUpdatesOneBlock (w.trackedGames,
+                             ZMQGameBlocksNotifier::PREFIX_ATTACH, pindex);
+      LogPrint (BCLog::GAME, "Finished processing sendupdates: %s\n",
+                w.str ().c_str ());
+    }
+#endif // ENABLE_ZMQ
+}
+
+void
+SendUpdatesWorker::interrupt ()
+{
+  WaitableLock lock(csWork);
+  interrupted = true;
+  cvWork.notify_all ();
+}
+
+void
+SendUpdatesWorker::enqueue (Work&& w)
+{
+  WaitableLock lock(csWork);
+
+  if (interrupted)
+    {
+      LogPrint (BCLog::GAME, "Not enqueueing work because interrupted: %s\n",
+                w.str ().c_str ());
+      return;
+    }
+
+  LogPrint (BCLog::GAME, "Enqueueing for sendupdates: %s\n", w.str ().c_str ());
+  work.push (std::move (w));
+  cvWork.notify_all ();
+}
+
+std::unique_ptr<SendUpdatesWorker> g_send_updates_worker;
+
+/* ************************************************************************** */
+namespace
+{
+
+#if ENABLE_ZMQ
+std::vector<const CBlockIndex*>
+GetDetachSequence (const CBlockIndex* from, const CBlockIndex* ancestor)
+{
+  std::vector<const CBlockIndex*> detach;
+  for (const auto* pindex = from; pindex != ancestor;
+       pindex = pindex->pprev)
+    {
+      LOCK (cs_main);
+
+      assert (pindex != nullptr);
+      if (!(pindex->nStatus & BLOCK_HAVE_DATA))
+        throw JSONRPCError (RPC_DATABASE_ERROR, "detached block has no data");
+
+      detach.push_back (pindex);
+    }
+
+  return detach;
+}
+#endif // ENABLE_ZMQ
+
+UniValue
+game_sendupdates (const JSONRPCRequest& request)
+{
+  if (request.fHelp || request.params.size () < 2 || request.params.size () > 3)
+    throw std::runtime_error (
+        "game_sendupdates \"gameid\" \"fromblock\" (\"toblock\")\n"
+        "\nSend on-demand block attach/detach notifications through the game"
+        " ZMQ interface.\n"
+        "\nArguments:\n"
+        "1. \"gameid\"          (string, required) the gameid for which to send notifications\n"
+        "2. \"fromblock\"       (string, required) starting block hash\n"
+        "3. \"toblock\"         (string, optional) target block hash (defaults to current tip)\n"
+        "\nResult:\n"
+        "{\n"
+        "  \"toblock\": xxx,    (string) the target block hash to which notifications have been triggered\n"
+        "  \"ancestor\": xxx,   (string) hash of the common ancestor that is used\n"
+        "  \"steps\":\n"
+        "   {\n"
+        "     \"detach\": n,    (numeric) number of detach notifications that will be sent\n"
+        "     \"attach\": n,    (numeric) number of attach notifications that will be sent\n"
+        "   },\n"
+        "}\n"
+        "\nExamples:\n"
+        + HelpExampleCli ("game_sendupdates", "\"huc\" \"e5062d76e5f50c42f493826ac9920b63a8def2626fd70a5cec707ec47a4c4651\"")
+        + HelpExampleCli ("game_sendupdates", "\"huc\" \"e5062d76e5f50c42f493826ac9920b63a8def2626fd70a5cec707ec47a4c4651\" \"206c22b7fb26b24b344b5b238325916c8bae4513302403f9f8efaf8b4c3e61f4\"")
+        + HelpExampleRpc ("game_sendupdates", "\"huc\", \"e5062d76e5f50c42f493826ac9920b63a8def2626fd70a5cec707ec47a4c4651\"")
+      );
+
+#if ENABLE_ZMQ
+  RPCTypeCheck (request.params,
+                {UniValue::VSTR, UniValue::VSTR, UniValue::VSTR});
+
+  SendUpdatesWorker::Work w;
+
+  w.trackedGames = {request.params[0].get_str ()};
+  const uint256 fromBlock = ParseHashV (request.params[1].get_str (),
+                                        "fromblock");
+
+  uint256 toBlock;
+  if (request.params.size () >= 3)
+    toBlock = ParseHashV (request.params[2].get_str (), "toblock");
+  else
+    {
+      LOCK (cs_main);
+      toBlock = chainActive.Tip ()->GetBlockHash ();
+    }
+
+  const CBlockIndex* fromIndex;
+  const CBlockIndex* toIndex;
+  {
+    LOCK (cs_main);
+
+    fromIndex = LookupBlockIndex (fromBlock);
+    toIndex = LookupBlockIndex (toBlock);
+
+    if (fromIndex == nullptr)
+      throw JSONRPCError (RPC_INVALID_ADDRESS_OR_KEY, "fromblock not found");
+    if (toIndex == nullptr)
+      throw JSONRPCError (RPC_INVALID_ADDRESS_OR_KEY, "toblock not found");
+
+    if (!(fromIndex->nStatus & BLOCK_HAVE_DATA))
+      throw JSONRPCError (RPC_DATABASE_ERROR, "fromblock has no data");
+    if (!(toIndex->nStatus & BLOCK_HAVE_DATA))
+      throw JSONRPCError (RPC_DATABASE_ERROR, "toblock has no data");
+  }
+
+  const CBlockIndex* ancestor = LastCommonAncestor (fromIndex, toIndex);
+  assert (ancestor != nullptr);
+
+  w.detach = GetDetachSequence (fromIndex, ancestor);
+  w.attach = GetDetachSequence (toIndex, ancestor);
+  std::reverse (w.attach.begin (), w.attach.end ());
+
+  UniValue result(UniValue::VOBJ);
+  result.pushKV ("toblock", toBlock.GetHex ());
+  result.pushKV ("ancestor", ancestor->GetBlockHash ().GetHex ());
+  UniValue steps(UniValue::VOBJ);
+  steps.pushKV ("detach", w.detach.size ());
+  steps.pushKV ("attach", w.attach.size ());
+  result.pushKV ("steps", steps);
+
+  if (g_zmq_notification_interface == nullptr)
+    throw JSONRPCError (RPC_MISC_ERROR, "ZMQ notifications are disabled");
+  if (g_zmq_notification_interface->GetGameBlocksNotifier () == nullptr)
+    throw JSONRPCError (RPC_MISC_ERROR, "-zmqpubgameblocks is not set");
+
+  assert (g_send_updates_worker != nullptr);
+  g_send_updates_worker->enqueue (std::move (w));
+
+  return result;
+#else // ENABLE_ZMQ
+  throw JSONRPCError (RPC_MISC_ERROR, "ZMQ is not built into Xaya");
+#endif // ENABLE_ZMQ
+}
+
+} // anonymous namespace
+/* ************************************************************************** */
+
+namespace
+{
+
+const CRPCCommand commands[] =
+{ //  category              name                      actor (function)         argNames
+  //  --------------------- ------------------------  -----------------------  ----------
+    { "game",               "game_sendupdates",       &game_sendupdates,       {"gameid","fromblock","toblock"} },
+};
+
+} // anonymous namespace
+
+void RegisterGameRPCCommands (CRPCTable& t)
+{
+  for (const auto& c : commands)
+    t.appendCommand (c.name, &c);
+}

--- a/src/rpc/game.h
+++ b/src/rpc/game.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2018 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_RPC_GAME_H
+#define BITCOIN_RPC_GAME_H
+
+#include <sync.h>
+
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+class CBlockIndex;
+
+/**
+ * The worker for game_sendupdates.  It maintains a queue of work items to
+ * process and has a thread that reads the items and performs the work.  It is
+ * exposed publicly so that init.cpp can start/interrupt/stop as necessary.
+ */
+class SendUpdatesWorker
+{
+
+public:
+
+  struct Work
+  {
+
+    std::vector<const CBlockIndex*> detach;
+    std::vector<const CBlockIndex*> attach;
+    std::set<std::string> trackedGames;
+
+    /* We only allow moving and enforce this by deleted copy constructors.  */
+    Work () = default;
+    Work (Work&&) = default;
+    Work (const Work&) = delete;
+    Work& operator= (Work&&) = default;
+    void operator= (const Work&) = delete;
+
+    std::string str () const;
+
+  };
+
+private:
+
+  std::queue<Work> work;
+  bool interrupted;
+
+  CWaitableCriticalSection csWork;
+  CConditionVariable cvWork;
+
+  std::unique_ptr<std::thread> runner;
+
+  static void run (SendUpdatesWorker& self);
+
+public:
+
+  SendUpdatesWorker ();
+  ~SendUpdatesWorker ();
+
+  SendUpdatesWorker (const SendUpdatesWorker&) = delete;
+  void operator= (const SendUpdatesWorker&) = delete;
+
+  void interrupt ();
+  void enqueue (Work&& w);
+
+};
+
+extern std::unique_ptr<SendUpdatesWorker> g_send_updates_worker;
+
+#endif // BITCOIN_RPC_GAME_H

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -21,6 +21,8 @@ void RegisterMiningRPCCommands(CRPCTable &tableRPC);
 void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC);
 /** Register Namecoin RPC commands */
 void RegisterNameRPCCommands(CRPCTable &tableRPC);
+/** Register Xaya game RPC commands */
+void RegisterGameRPCCommands(CRPCTable &tableRPC);
 
 static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
 {
@@ -30,6 +32,7 @@ static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
     RegisterMiningRPCCommands(t);
     RegisterRawTransactionRPCCommands(t);
     RegisterNameRPCCommands(t);
+    RegisterGameRPCCommands(t);
 }
 
 #endif // BITCOIN_RPC_REGISTER_H

--- a/src/zmq/zmqgames.h
+++ b/src/zmq/zmqgames.h
@@ -21,6 +21,11 @@ class UniValue;
 class ZMQGameBlocksNotifier : public CZMQAbstractPublishNotifier
 {
 
+public:
+
+  static const char* PREFIX_ATTACH;
+  static const char* PREFIX_DETACH;
+
 private:
 
   /** The set of games tracked by this notifier.  */
@@ -31,13 +36,6 @@ private:
    */
   bool SendMessage (const std::string& command, const UniValue& data);
 
-  /**
-   * Sends the block attach or detach notifications.  They are essentially the
-   * same, except that they have a different command string.
-   */
-  bool SendBlockNotifications (const std::string& commandPrefix,
-                               const CBlock& block, const CBlockIndex* pindex);
-
 public:
 
   ZMQGameBlocksNotifier () = delete;
@@ -45,6 +43,14 @@ public:
   explicit ZMQGameBlocksNotifier (const std::set<std::string>& games)
     : trackedGames(games)
   {}
+
+  /**
+   * Sends the block attach or detach notifications.  They are essentially the
+   * same, except that they have a different command string.
+   */
+  bool SendBlockNotifications (const std::set<std::string>& games,
+                               const std::string& commandPrefix,
+                               const CBlock& block, const CBlockIndex* pindex);
 
   bool NotifyBlockAttached (const CBlock& block,
                             const CBlockIndex* pindex) override;

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -53,8 +53,11 @@ CZMQNotificationInterface* CZMQNotificationInterface::Create()
 
     const std::vector<std::string> vTrackedGames = gArgs.GetArgs("-trackgame");
     const std::set<std::string> trackedGames(vTrackedGames.begin(), vTrackedGames.end());
-    factories["pubgameblocks"] = [&trackedGames]() {
-        return new ZMQGameBlocksNotifier(trackedGames);
+    ZMQGameBlocksNotifier* gameBlocksNotifier = nullptr;
+    factories["pubgameblocks"] = [&trackedGames, &gameBlocksNotifier]() {
+        assert (gameBlocksNotifier == nullptr);
+        gameBlocksNotifier = new ZMQGameBlocksNotifier(trackedGames);
+        return gameBlocksNotifier;
     };
 
     for (const auto& entry : factories)
@@ -75,6 +78,7 @@ CZMQNotificationInterface* CZMQNotificationInterface::Create()
     {
         notificationInterface = new CZMQNotificationInterface();
         notificationInterface->notifiers = notifiers;
+        notificationInterface->gameBlocksNotifier = gameBlocksNotifier;
 
         if (!notificationInterface->Initialize())
         {

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -12,6 +12,7 @@
 
 class CBlockIndex;
 class CZMQAbstractNotifier;
+class ZMQGameBlocksNotifier;
 
 class CZMQNotificationInterface final : public CValidationInterface
 {
@@ -21,6 +22,10 @@ public:
     std::list<const CZMQAbstractNotifier*> GetActiveNotifiers() const;
 
     static CZMQNotificationInterface* Create();
+
+    inline ZMQGameBlocksNotifier* GetGameBlocksNotifier() {
+        return gameBlocksNotifier;
+    }
 
 protected:
     bool Initialize();
@@ -37,6 +42,12 @@ private:
 
     void *pcontext;
     std::list<CZMQAbstractNotifier*> notifiers;
+
+    /**
+     * The game blocks notifier, if any.  This is used to send on-demand
+     * notifications for game_sendupdates.
+     */
+    ZMQGameBlocksNotifier* gameBlocksNotifier;
 };
 
 extern CZMQNotificationInterface* g_zmq_notification_interface;


### PR DESCRIPTION
This implements the `game_sendupdates` RPC command as specified in #53.  With this, games can request on-demand notifications for block attaches/detaches, so that they can recover from an out-of-sync situation or sync from scratch.