### PR TITLE
Make "signmessage" magic Xaya-specific

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -241,7 +241,7 @@ std::atomic_bool g_is_mempool_loaded{false};
 /** Constant stuff for coinbase transactions we create: */
 CScript COINBASE_FLAGS;
 
-const std::string strMessageMagic = "Namecoin Signed Message:\n";
+const std::string strMessageMagic = "Xaya Signed Message:\n";
 
 // Internal stuff
 namespace {

--- a/test/functional/rpc_signmessage.py
+++ b/test/functional/rpc_signmessage.py
@@ -19,7 +19,7 @@ class SignMessagesTest(BitcoinTestFramework):
         self.log.info('test signing with priv_key')
         priv_key = 'b9Re9AqiHcCp1L1UB9QwFfSHdc5d9vS7km7PX6Vt3sPAjmCAQzYc'
         address = 'cZZY6ATUpST3PWrVnequMHTytE2S7uZGYL'
-        expected_signature = 'Hx6I/QmVmh4EePAdNrPm1ud7M/w6r9Oz2FNMUz4jxTPnW3FiYTTjNWzV1ESB2NeeoAIG7hEsNVRaVFLyE3dG2VE='
+        expected_signature = 'H16OYOEyKo8Sz3UWB6Qc8kNn3omIw+a6yCtufZGG27d2em1k0Mw8a6L7Im8d/Nnpehv0xwjsAUkecRE0VlUg6/8='
         signature = self.nodes[0].signmessagewithprivkey(priv_key, message)
         assert_equal(expected_signature, signature)
         assert(self.nodes[0].verifymessage(address, signature, message))


### PR DESCRIPTION
Use a Xaya-specific "magic string" for `signmessage`/`verifymessage` instead of the Bitcoin-one.  This ensures that signatures have to be verified with Xaya, as users likely expect.

This corresponds to a recent similar change in upstream Namecoin:  https://github.com/namecoin/namecoin-core/pull/248