### PR TITLE
Add reqtoken and other adaptions to ZMQ interface

### DIFF
--- a/src/rpc/game.h
+++ b/src/rpc/game.h
@@ -29,6 +29,7 @@ public:
   struct Work
   {
 
+    std::string reqtoken;
     std::vector<const CBlockIndex*> detach;
     std::vector<const CBlockIndex*> attach;
     std::set<std::string> trackedGames;

--- a/src/zmq/zmqgames.cpp
+++ b/src/zmq/zmqgames.cpp
@@ -154,6 +154,7 @@ ZMQGameBlocksNotifier::SendBlockNotifications (
   tmpl.pushKV ("child", block.GetHash ().GetHex ());
   if (!reqtoken.empty ())
     tmpl.pushKV ("reqtoken", reqtoken);
+  tmpl.pushKV ("rngseed", block.GetRngSeed ().GetHex ());
 
   /* Send notifications for all games with the moves merged into the
      template object.  */

--- a/src/zmq/zmqgames.cpp
+++ b/src/zmq/zmqgames.cpp
@@ -121,7 +121,7 @@ JsonDataForMove (const CTransaction& tx)
 bool
 ZMQGameBlocksNotifier::SendBlockNotifications (
     const std::set<std::string>& games, const std::string& commandPrefix,
-    const CBlock& block, const CBlockIndex* pindex)
+    const std::string& reqtoken, const CBlock& block, const CBlockIndex* pindex)
 {
   /* Start with an empty array of moves for each game that we track.  */
   std::map<std::string, UniValue> perGameMoves;
@@ -152,6 +152,8 @@ ZMQGameBlocksNotifier::SendBlockNotifications (
       tmpl.pushKV ("parent", pindex->pprev->GetBlockHash ().GetHex ());
     }
   tmpl.pushKV ("child", block.GetHash ().GetHex ());
+  if (!reqtoken.empty ())
+    tmpl.pushKV ("reqtoken", reqtoken);
 
   /* Send notifications for all games with the moves merged into the
      template object.  */
@@ -175,7 +177,8 @@ ZMQGameBlocksNotifier::NotifyBlockAttached (const CBlock& block,
                                             const CBlockIndex* pindex)
 {
   LOCK (csTrackedGames);
-  return SendBlockNotifications (trackedGames, PREFIX_ATTACH, block, pindex);
+  return SendBlockNotifications (trackedGames, PREFIX_ATTACH, "",
+                                 block, pindex);
 }
 
 bool
@@ -183,7 +186,8 @@ ZMQGameBlocksNotifier::NotifyBlockDetached (const CBlock& block,
                                             const CBlockIndex* pindex)
 {
   LOCK (csTrackedGames);
-  return SendBlockNotifications (trackedGames, PREFIX_DETACH, block, pindex);
+  return SendBlockNotifications (trackedGames, PREFIX_DETACH, "",
+                                 block, pindex);
 }
 
 UniValue

--- a/src/zmq/zmqgames.h
+++ b/src/zmq/zmqgames.h
@@ -53,6 +53,7 @@ public:
    */
   bool SendBlockNotifications (const std::set<std::string>& games,
                                const std::string& commandPrefix,
+                               const std::string& reqtoken,
                                const CBlock& block, const CBlockIndex* pindex);
 
   bool NotifyBlockAttached (const CBlock& block,

--- a/test/functional/xaya_gameblocks.py
+++ b/test/functional/xaya_gameblocks.py
@@ -297,9 +297,14 @@ class GameBlocksTest (BitcoinTestFramework):
       blks.extend (self.node.generate (1))
       topic, data = self.games["a"].receive ()
       assert_equal (topic, "game-block-attach json a")
+      if len (attachA) > 0:
+        assert_equal (attachA[-1]['child'], data['parent'])
       attachA.append (data)
+
       topic, data = self.games["b"].receive ()
       assert_equal (topic, "game-block-attach json b")
+      if len (attachB) > 0:
+        assert_equal (attachB[-1]['child'], data['parent'])
       attachB.append (data)
 
     return blks, attachA, attachB

--- a/test/functional/xaya_gameblocks.py
+++ b/test/functional/xaya_gameblocks.py
@@ -118,7 +118,7 @@ class GameBlocksTest (BitcoinTestFramework):
     try:
       self._test_currencyIgnored ()
       self._test_register ()
-      self._test_blockHashes ()
+      self._test_blockData ()
       self._test_multipleUpdates ()
       self._test_moveWithCurrency ()
       self._test_reorg ()
@@ -170,17 +170,23 @@ class GameBlocksTest (BitcoinTestFramework):
     _, data = self.games["b"].receive ()
     assert_equal (data["moves"], [])
 
-  def _test_blockHashes (self):
+  def _test_blockData (self):
     """
-    Verifies the block hashes (parent and child) in the main message that
-    is sent against the blockchain.
+    Verifies the block-related data (parent/child hashes, rngseed) in the main
+    message that is sent against the blockchain.
     """
 
-    self.log.info ("Verifying block hashes...")
+    self.log.info ("Verifying block data...")
 
     parent = self.node.getbestblockhash ()
     child = self.node.generate (1)[0]
-    expected = {"parent": parent, "child": child, "moves": []}
+    data = self.node.getblock (child)
+    expected = {
+        "parent": parent,
+        "child": child,
+        "rngseed": data['rngseed'],
+        "moves": []
+    }
 
     for g in ["a", "b"]:
       _, data = self.games[g].receive ()


### PR DESCRIPTION
This adds the `reqtoken` and `rngseed` fields to the ZMQ game interface, as described in #61.