### PR TITLE
Add -maxgameblockattaches option and limit

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -518,6 +518,8 @@ void SetupServerArgs()
     gArgs.AddArg("-nameencoding=<enc>", strprintf("Sets the default encoding used for names in the RPC interface (default: %s)", EncodingToString(DEFAULT_NAME_ENCODING)), false, OptionsCategory::RPC);
     gArgs.AddArg("-valueencoding=<enc>", strprintf("Sets the default encoding used for values in the RPC interface (default: %s)", EncodingToString(DEFAULT_VALUE_ENCODING)), false, OptionsCategory::RPC);
 
+    gArgs.AddArg("-maxgameblockattaches=<n>", strprintf("Sets the maximum number of attach steps sent for a single game_sendupdates request (default: %d)", DEFAULT_MAX_GAME_BLOCK_ATTACHES), false, OptionsCategory::RPC);
+
 #if HAVE_DECL_DAEMON
     gArgs.AddArg("-daemon", "Run in the background as a daemon and accept commands", false, OptionsCategory::OPTIONS);
 #else

--- a/src/rpc/game.h
+++ b/src/rpc/game.h
@@ -18,6 +18,12 @@
 class CBlockIndex;
 
 /**
+ * Default value for the -maxgameblockattaches option, which determines how
+ * many attach steps are sent at most for a single game_sendupdates request.
+ */
+static constexpr unsigned DEFAULT_MAX_GAME_BLOCK_ATTACHES = 1000;
+
+/**
  * The worker for game_sendupdates.  It maintains a queue of work items to
  * process and has a thread that reads the items and performs the work.  It is
  * exposed publicly so that init.cpp can start/interrupt/stop as necessary.


### PR DESCRIPTION
The new option `-maxgameblockattaches` (default: 1000) can be used to specify the maximum number of block attach steps that will be sent in response to a single `game_sendupdates` request.  The RPC response will always indicate the `toblock` correctly, i.e. give the block to which notifications will be sent (after limiting).

This won't impact client software like [`libxayagame`](https://github.com/xaya/libxayagame), as it will expect notifications to the returned `toblock` and then just request more updates if necessary.

With this limit, we avoid problems with very large requests (e.g. the whole chain when a game is synced from scratch) that will run for minutes and block other requests for notifications in the mean time.  With the limit, those requests will be interleaved as each individual request can only take a small amount of processing.

Note that a similar limit for *detach* notifications is not necessary, because (under normal operation) detaches are expected to be very short (a few blocks at most, corresponding to reorgs).  Attaches on the other hand *can* be very long, up to the length of the full chain.

This fixes https://github.com/xaya/xaya/issues/65.