### PR TITLE
Implement "post ICO" fork

### DIFF
--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -10,6 +10,7 @@
 #include <compat/endian.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
+#include <consensus/params.h>
 #include <hash.h>
 #include <primitives/block.h>
 #include <script/script.h>

--- a/src/auxpow.h
+++ b/src/auxpow.h
@@ -7,7 +7,6 @@
 #ifndef BITCOIN_AUXPOW_H
 #define BITCOIN_AUXPOW_H
 
-#include <consensus/params.h>
 #include <primitives/pureheader.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
@@ -20,6 +19,11 @@ class CBlock;
 class CBlockIndex;
 class CValidationState;
 class UniValue;
+
+namespace Consensus
+{
+class Params;
+}
 
 namespace auxpow_tests
 {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -167,7 +167,9 @@ public:
     CMainParams() {
         strNetworkID = "main";
         consensus.nSubsidyHalvingInterval = 4200000;
-        consensus.initialSubsidy = 1 * COIN;
+        /* FIXME: Set to actual value that yields the right total supply
+           after the post-ICO fork height is fixed.  */
+        consensus.initialSubsidy = 10 * COIN;
         consensus.BIP16Height = 0;
         consensus.BIP34Height = 1;
         consensus.BIP65Height = 0;
@@ -264,7 +266,7 @@ public:
     CTestNetParams() {
         strNetworkID = "test";
         consensus.nSubsidyHalvingInterval = 4200000;
-        consensus.initialSubsidy = 1 * COIN;
+        consensus.initialSubsidy = 10 * COIN;
         consensus.BIP16Height = 0;
         consensus.BIP34Height = 1;
         consensus.BIP65Height = 0;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -173,9 +173,6 @@ public:
         consensus.BIP65Height = 0;
         consensus.BIP66Height = 0;
         consensus.powLimitNeoscrypt = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        /* The target spacing is independent for each mining algorithm, so that
-           the effective block frequency is half the value (with two algos).  */
-        consensus.nPowTargetSpacing = 2 * 30;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
         consensus.nMinerConfirmationWindow = 2016;
@@ -273,7 +270,6 @@ public:
         consensus.BIP65Height = 0;
         consensus.BIP66Height = 0;
         consensus.powLimitNeoscrypt = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetSpacing = 2 * 30;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
         consensus.nMinerConfirmationWindow = 2016;
@@ -367,7 +363,6 @@ public:
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
         consensus.powLimitNeoscrypt = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetSpacing = 2 * 30;
         consensus.fPowNoRetargeting = true;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
         consensus.nMinerConfirmationWindow = 144; // Faster than normal for regtest (144 instead of 2016)
@@ -512,4 +507,40 @@ void TurnOffSegwitForUnitTests ()
      we would have to have an explicit argument for BIP16.  */
   auto* params = const_cast<CChainParams*> (globalChainParams.get ());
   params->TurnOffSegwitForUnitTests ();
+}
+
+int64_t
+AvgTargetSpacing (const Consensus::Params& params, const unsigned height)
+{
+  /* The average target spacing for any block (all algorithms combined) is
+     computed by dividing some common multiple timespan of all spacings
+     by the number of blocks expected (all algorithms together) in that
+     time span.
+
+     The numerator is simply the product of all block times, while the
+     denominator is a sum of products that just excludes the current
+     algorithm (i.e. of all (N-1) tuples selected from the N algorithm
+     block times).  */
+  int64_t numer = 1;
+  int64_t denom = 0;
+  for (const PowAlgo algo : {PowAlgo::SHA256D, PowAlgo::NEOSCRYPT})
+    {
+      const int64_t spacing = params.rules->GetTargetSpacing(algo, height);
+
+      /* Multiply all previous added block counts by this target spacing.  */
+      denom *= spacing;
+
+      /* Add the number of blocks for the current algorithm to the denominator.
+         This starts off with the product of all already-processed algorithms
+         (excluding the current one), and will be multiplied later on by
+         the still-to-be-processed ones (in the line above).  */
+      denom += numer;
+
+      /* The numerator is the product of all spacings.  */
+      numer *= spacing;
+    }
+
+  assert (denom > 0);
+  assert (numer % denom == 0);
+  return numer / denom;
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -131,4 +131,11 @@ void SelectParams(const std::string& chain);
  */
 void TurnOffSegwitForUnitTests();
 
+/**
+ * Returns the average target spacing of blocks (including all algorithms)
+ * at the given block height.  This is used for situations where we simply
+ * want to know the expected number of blocks in a given time frame.
+ */
+int64_t AvgTargetSpacing(const Consensus::Params& params, unsigned height);
+
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -17,6 +17,25 @@
 namespace Consensus {
 
 /**
+ * Identifiers for forks done on the network, so that validation code can
+ * easily just query whether or not a particular fork should be active and
+ * does not have to bother with the particular heights or other aspects.
+ */
+enum class Fork
+{
+
+  /**
+   * Fork done after the token sale.  This removed the requirement that the
+   * main (non-fakeheader) nonce must be zero in order to resolve
+   * https://github.com/xaya/xaya/issues/50.
+   *
+   * TODO: Also adjust block rewards to give the final coin supply.
+   */
+  POST_ICO,
+
+};
+
+/**
  * Interface for classes that define consensus behaviour in more
  * complex ways than just by a set of constants.
  */
@@ -30,24 +49,69 @@ public:
     /* Return minimum locked amount in a name.  */
     virtual CAmount MinNameCoinAmount(unsigned nHeight) const = 0;
 
+    /**
+     * Checks whether a given fork is in effect at the given block height.
+     */
+    virtual bool ForkInEffect(Fork type, unsigned height) const = 0;
+
 };
 
 class MainNetConsensus : public ConsensusRules
 {
 public:
 
-    CAmount MinNameCoinAmount(unsigned nHeight) const
+    CAmount MinNameCoinAmount(unsigned nHeight) const override
     {
         return COIN / 100;
+    }
+
+    bool ForkInEffect(const Fork type, const unsigned height) const override
+    {
+        switch (type)
+        {
+            case Fork::POST_ICO:
+                /* FIXME: Set correct height once determined.  */
+                return height >= 1000000;
+            default:
+                assert (false);
+        }
     }
 
 };
 
 class TestNetConsensus : public MainNetConsensus
-{};
+{
+public:
+
+    bool ForkInEffect(const Fork type, const unsigned height) const override
+    {
+        switch (type)
+        {
+            case Fork::POST_ICO:
+                /* FIXME: Set correct height once determined.  */
+                return height >= 1000000;
+            default:
+                assert (false);
+        }
+    }
+
+};
 
 class RegTestConsensus : public TestNetConsensus
-{};
+{
+public:
+
+    bool ForkInEffect(const Fork type, const unsigned height) const override
+    {
+        switch (type)
+        {
+            case Fork::POST_ICO:
+                return height >= 500;
+            default:
+                assert (false);
+        }
+    }
+};
 
 enum DeploymentPos
 {

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -121,8 +121,7 @@ public:
         switch (type)
         {
             case Fork::POST_ICO:
-                /* FIXME: Set correct height once determined.  */
-                return height >= 1000000;
+                return height >= 11000;
             default:
                 assert (false);
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -484,12 +484,12 @@ static bool TipMayBeStale(const Consensus::Params &consensusParams) EXCLUSIVE_LO
     if (g_last_tip_update == 0) {
         g_last_tip_update = GetTime();
     }
-    return g_last_tip_update < GetTime() - consensusParams.nPowTargetSpacing * 3 && mapBlocksInFlight.empty();
+    return g_last_tip_update < GetTime() - AvgTargetSpacing(consensusParams, chainActive.Height()) * 3 && mapBlocksInFlight.empty();
 }
 
 static bool CanDirectFetch(const Consensus::Params &consensusParams) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    return chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - consensusParams.nPowTargetSpacing * 20;
+    return chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - AvgTargetSpacing(consensusParams, chainActive.Height()) * 20;
 }
 
 static bool PeerHasHeader(CNodeState *state, const CBlockIndex *pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
@@ -2070,7 +2070,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             }
             // If pruning, don't inv blocks unless we have on disk and are likely to still have
             // for some reasonable time window (1 hour) that block relay might require.
-            const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 3600 / chainparams.GetConsensus().nPowTargetSpacing;
+            const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 3600 / AvgTargetSpacing(chainparams.GetConsensus(), chainActive.Height());
             if (fPruneMode && (!(pindex->nStatus & BLOCK_HAVE_DATA) || pindex->nHeight <= chainActive.Tip()->nHeight - nPrunedBlocksLikelyToHave))
             {
                 LogPrint(BCLog::NET, " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
@@ -3363,7 +3363,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
             // Only actively request headers from a single peer, unless we're close to today.
             if ((nSyncStarted == 0 && fFetch) || pindexBestHeader->GetBlockTime() > GetAdjustedTime() - 24 * 60 * 60) {
                 state.fSyncStarted = true;
-                state.nHeadersSyncTimeout = GetTimeMicros() + HEADERS_DOWNLOAD_TIMEOUT_BASE + HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER * (GetAdjustedTime() - pindexBestHeader->GetBlockTime())/(consensusParams.nPowTargetSpacing);
+                state.nHeadersSyncTimeout = GetTimeMicros() + HEADERS_DOWNLOAD_TIMEOUT_BASE + HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER * (GetAdjustedTime() - pindexBestHeader->GetBlockTime())/(AvgTargetSpacing(consensusParams, pindexBestHeader->nHeight));
                 nSyncStarted++;
                 const CBlockIndex *pindexStart = pindexBestHeader;
                 /* If possible, start at the block preceding the currently
@@ -3683,7 +3683,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
         if (state.vBlocksInFlight.size() > 0) {
             QueuedBlock &queuedBlock = state.vBlocksInFlight.front();
             int nOtherPeersWithValidatedDownloads = nPeersWithValidatedDownloads - (state.nBlocksInFlightValidHeaders > 0);
-            if (nNow > state.nDownloadingSince + consensusParams.nPowTargetSpacing * (BLOCK_DOWNLOAD_TIMEOUT_BASE + BLOCK_DOWNLOAD_TIMEOUT_PER_PEER * nOtherPeersWithValidatedDownloads)) {
+            if (nNow > state.nDownloadingSince + AvgTargetSpacing(consensusParams, chainActive.Height()) * (BLOCK_DOWNLOAD_TIMEOUT_BASE + BLOCK_DOWNLOAD_TIMEOUT_PER_PEER * nOtherPeersWithValidatedDownloads)) {
                 LogPrintf("Timeout downloading block %s from peer=%d, disconnecting\n", queuedBlock.hash.ToString(), pto->GetId());
                 pto->fDisconnect = true;
                 return true;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -60,7 +60,9 @@ GetNextWorkRequired (const PowAlgo algo, const CBlockIndex* pindexLast,
 
   int64_t nActualTimespan = pindexLast->GetBlockTime ()
                               - pindexFirst->GetBlockTime ();
-  int64_t nTargetTimespan = nPastBlocks * params.nPowTargetSpacing;
+  const int nextHeight = pindexLast->nHeight + 1;
+  int64_t nTargetTimespan
+      = nPastBlocks * params.rules->GetTargetSpacing(algo, nextHeight);
 
   if (nActualTimespan < nTargetTimespan / 3)
     nActualTimespan = nTargetTimespan / 3;

--- a/src/powdata.cpp
+++ b/src/powdata.cpp
@@ -5,6 +5,7 @@
 #include <powdata.h>
 
 #include <arith_uint256.h>
+#include <consensus/params.h>
 #include <util.h>
 
 #include <sstream>

--- a/src/powdata.h
+++ b/src/powdata.h
@@ -6,7 +6,6 @@
 #define BITCOIN_POWDATA_H
 
 #include <auxpow.h>
-#include <consensus/params.h>
 #include <primitives/pureheader.h>
 #include <serialize.h>
 #include <uint256.h>
@@ -15,6 +14,11 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+
+namespace Consensus
+{
+class Params;
+}
 
 namespace powdata_tests
 {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -768,7 +768,7 @@ void BitcoinGUI::updateHeadersSyncProgressLabel()
 {
     int64_t headersTipTime = clientModel->getHeaderTipTime();
     int headersTipHeight = clientModel->getHeaderTipHeight();
-    int estHeadersLeft = (GetTime() - headersTipTime) / Params().GetConsensus().nPowTargetSpacing;
+    int estHeadersLeft = (GetTime() - headersTipTime) / AvgTargetSpacing(Params().GetConsensus(), headersTipHeight);
     if (estHeadersLeft > HEADER_HEIGHT_DELTA_SYNC)
         progressBarLabel->setText(tr("Syncing Headers (%1%)...").arg(QString::number(100.0 / (headersTipHeight+estHeadersLeft)*headersTipHeight, 'f', 1)));
 }

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -129,7 +129,7 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
 
     // estimate the number of headers left based on nPowTargetSpacing
     // and check if the gui is not aware of the best header (happens rarely)
-    int estimateNumHeadersLeft = bestHeaderDate.secsTo(currentDate) / Params().GetConsensus().nPowTargetSpacing;
+    int estimateNumHeadersLeft = bestHeaderDate.secsTo(currentDate) / AvgTargetSpacing(Params().GetConsensus(), bestHeaderHeight);
     bool hasBestHeader = bestHeaderHeight >= count;
 
     // show remaining number of blocks

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -167,7 +167,7 @@ void SendCoinsDialog::setModel(WalletModel *_model)
 
         // fee section
         for (const int n : confTargets) {
-            ui->confTargetSelector->addItem(tr("%1 (%2 blocks)").arg(GUIUtil::formatNiceTimeOffset(n*Params().GetConsensus().nPowTargetSpacing)).arg(n));
+            ui->confTargetSelector->addItem(tr("%1 (%2 blocks)").arg(GUIUtil::formatNiceTimeOffset(n*AvgTargetSpacing(Params().GetConsensus(), clientModel->getHeaderTipHeight()))).arg(n));
         }
         connect(ui->confTargetSelector, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &SendCoinsDialog::updateSmartFeeLabel);
         connect(ui->confTargetSelector, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &SendCoinsDialog::coinControlUpdateLabels);

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -4,6 +4,7 @@
 #include <interfaces/node.h>
 #include <base58.h>
 #include <qt/bitcoinamountfield.h>
+#include <qt/clientmodel.h>
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>
 #include <qt/qvalidatedlineedit.h>
@@ -154,9 +155,11 @@ void TestGUI()
     TransactionView transactionView(platformStyle.get());
     auto node = interfaces::MakeNode();
     OptionsModel optionsModel(*node);
+    ClientModel clientModel(*node, &optionsModel);
     AddWallet(wallet);
     WalletModel walletModel(std::move(node->getWallets().back()), *node, platformStyle.get(), &optionsModel);
     RemoveWallet(wallet);
+    sendCoinsDialog.setClientModel(&clientModel);
     sendCoinsDialog.setModel(&walletModel);
     transactionView.setModel(&walletModel);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1660,8 +1660,6 @@ static UniValue getchaintxstats(const JSONRPCRequest& request)
         );
 
     const CBlockIndex* pindex;
-    int blockcount = 30 * 24 * 60 * 60 / Params().GetConsensus().nPowTargetSpacing; // By default: 1 month
-
     if (request.params[1].isNull()) {
         LOCK(cs_main);
         pindex = chainActive.Tip();
@@ -1678,6 +1676,8 @@ static UniValue getchaintxstats(const JSONRPCRequest& request)
     }
 
     assert(pindex != nullptr);
+
+    int blockcount = 30 * 24 * 60 * 60 / AvgTargetSpacing(Params().GetConsensus(), pindex->nHeight); // By default: 1 month
 
     if (request.params[0].isNull()) {
         blockcount = std::max(0, std::min(blockcount, pindex->nHeight - 1));

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
         BOOST_CHECK(node->fDisconnect == false);
     }
 
-    SetMockTime(GetTime() + 30*consensusParams.nPowTargetSpacing + 1);
+    SetMockTime(GetTime() + 30*AvgTargetSpacing(consensusParams, chainActive.Height()) + 1);
 
     // Now tip should definitely be stale, and we should look for an extra
     // outbound peer

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -69,8 +69,8 @@ BOOST_AUTO_TEST_CASE(subsidy_post_ico_fork_test)
     BOOST_CHECK_EQUAL(GetBlockSubsidy(1000000, main->GetConsensus()), 10 * COIN);
 
     const auto test = CreateChainParams(CBaseChainParams::TESTNET);
-    BOOST_CHECK_EQUAL(GetBlockSubsidy(999999, test->GetConsensus()), COIN);
-    BOOST_CHECK_EQUAL(GetBlockSubsidy(1000000, test->GetConsensus()), 10 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(10999, test->GetConsensus()), COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(11000, test->GetConsensus()), 10 * COIN);
 
     const auto regtest = CreateChainParams(CBaseChainParams::REGTEST);
     BOOST_CHECK_EQUAL(GetBlockSubsidy(1, regtest->GetConsensus()), 50 * COIN);

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -74,10 +74,7 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
     for (int i = 0; i < 10000; i++) {
         blocks[i].pprev = i ? &blocks[i - 1] : nullptr;
         blocks[i].nHeight = i;
-        /* During one nPowTargetSpacing, we get blocks *from each* algorithm.
-           Because of that, the actual spacing between two blocks (no matter
-           what the algo) is half of the target spacing.  */
-        blocks[i].nTime = 1269211443 + i * chainParams->GetConsensus().nPowTargetSpacing / 2;
+        blocks[i].nTime = 1269211443 + i * AvgTargetSpacing(chainParams->GetConsensus(), i);
         blocks[i].nBits = 0x207fffff; /* target 0x7fffff000... */
         if (i % 2 == 0)
           blocks[i].algo = PowAlgo::SHA256D;
@@ -96,7 +93,7 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
         /* Depending on which blocks exactly are chosen, there might be
            "off-by-one" type differences in the number of blocks of each algo.
            Thus we allow for a little mismatch.  */
-        BOOST_CHECK(std::abs(wdiff - tdiff) < chainParams->GetConsensus().nPowTargetSpacing);
+        BOOST_CHECK(std::abs(wdiff - tdiff) < 60);
     }
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1867,7 +1867,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                 //  artificially set the default assumed verified block further back.
                 // The test against nMinimumChainWork prevents the skipping when denied access to any chain at
                 //  least as good as the expected chain.
-                fScriptChecks = (GetBlockProofEquivalentTime(*pindexBestHeader, *pindex, *pindexBestHeader, chainparams.GetConsensus()) <= 60 * 60 * 24);
+                fScriptChecks = (GetBlockProofEquivalentTime(*pindexBestHeader, *pindex, *pindexBestHeader, chainparams.GetConsensus()) <= 60 * 60 * 12);
             }
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3163,10 +3163,19 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
     const int nHeight = pindexPrev->nHeight + 1;
 
     /* Verify Xaya's requirement that the main block header must have zero bits
-       and nonce.  */
-    if (block.nBits != 0 || block.nNonce != 0)
-        return state.Invalid(false, REJECT_INVALID, "nonzero-bits-nonce",
-                             "block header has non-zero nonce or bits");
+       (the difficulty is in the powdata instead).  */
+    if (block.nBits != 0)
+        return state.Invalid(false, REJECT_INVALID, "nonzero-bits",
+                             "block header has non-zero nonce");
+    /* Until the POST_ICO fork, also the nonce has to be zero.
+     *
+     * TODO: Remove this requirement after we are past the fork height!
+     */
+    if (!params.GetConsensus().rules->ForkInEffect(Consensus::Fork::POST_ICO,
+                                                   nHeight)
+          && block.nNonce != 0)
+        return state.Invalid(false, REJECT_INVALID, "nonzero-nonce",
+                             "block header has non-zero nonce");
 
     // Check proof of work
     const Consensus::Params& consensusParams = params.GetConsensus();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1191,6 +1191,14 @@ bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 {
+    /* Special rule:  Before the post-ICO fork, the block reward is always set
+       to 1 CHI except for regtest net.  (The latter exception is so that
+       we do not have to update many magic values in tests.)  */
+    if (!consensusParams.fPowNoRetargeting
+          && !consensusParams.rules->ForkInEffect (Consensus::Fork::POST_ICO,
+                                                   nHeight))
+        return COIN;
+
     int halvings = nHeight / consensusParams.nSubsidyHalvingInterval;
     // Force block reward to zero when right shift is undefined.
     if (halvings >= 64)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -213,6 +213,7 @@ BASE_SCRIPTS = [
     # Xaya-specific tests
     'xaya_dualalgo.py',
     'xaya_gameblocks.py',
+    'xaya_postico_fork.py',
     'xaya_premine.py',
 ]
 


### PR DESCRIPTION
This implements the planned "post ICO" hard fork.  For now, it is scheduled at height 500 on regtest, 11k on testnet and 1M on mainnet.  The mainnet height will be defined later after a (hopefully) successful activation on testnet.

This changes three things:

1. The nonce values of main block headers no longer need to be zero (#50).
2. The block intervals are changed and made algorithm-dependent:  Neoscrypt targets 40s and SHA-256d two minutes after the fork (for an average that is still 30s per block).  See #67 for the discussion.
3. The block rewards are increased to 10 CHI on testnet and mainnet after the fork.  For testnet, that is the (arbitrary) value we will use.  For mainnet, the value will be changed when the actual fork height becomes known, so that we can calculate the correct value.  This implements #40.