### PR TITLE
Set POST_ICO fork on mainnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -167,9 +167,12 @@ public:
     CMainParams() {
         strNetworkID = "main";
         consensus.nSubsidyHalvingInterval = 4200000;
-        /* FIXME: Set to actual value that yields the right total supply
-           after the post-ICO fork height is fixed.  */
-        consensus.initialSubsidy = 10 * COIN;
+        /* The value of ~3.8 CHI is calculated to yield the desired total
+           PoW coin supply.  For the calculation, see here:
+
+           https://github.com/xaya/xaya/issues/70#issuecomment-441292533
+        */
+        consensus.initialSubsidy = 382934346;
         consensus.BIP16Height = 0;
         consensus.BIP34Height = 1;
         consensus.BIP65Height = 0;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -30,7 +30,8 @@ enum class Fork
    * main (non-fakeheader) nonce must be zero in order to resolve
    * https://github.com/xaya/xaya/issues/50.
    *
-   * TODO: Also adjust block rewards to give the final coin supply.
+   * It also increases the block reward from 1 CHI to a value calculated to
+   * yield the correct total PoW supply.
    */
   POST_ICO,
 
@@ -103,8 +104,7 @@ public:
         switch (type)
         {
             case Fork::POST_ICO:
-                /* FIXME: Set correct height once determined.  */
-                return height >= 1000000;
+                return height >= 440000;
             default:
                 assert (false);
         }


### PR DESCRIPTION
This fixes the `POST_ICO` fork on mainnet to be at block **440k** and the initial block reward after the fork to **3.82934346 CHI** on mainnet.  This is [calculated](https://github.com/xaya/xaya/issues/70#issuecomment-441292533) to yield (slightly below) the targeted total PoW supply of **30,921,573 CHI**.

Also the unit test for the total subsidy is re-enabled to verify that the resulting PoW coin supply matches the expected amount.