### PR TITLE
Fix disk block index for non-zero nNonce values

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -225,6 +225,7 @@ public:
      * actual nBits, so that the total work of a chain can be computed from it.
      */
     uint32_t nBits;
+    uint32_t nNonce;
 
     /** Mining algorithm used (necessary to evaluate chain work).  */
     PowAlgo algo;
@@ -255,6 +256,7 @@ public:
         hashMerkleRoot = uint256();
         nTime          = 0;
         nBits          = 0;
+        nNonce         = 0;
 
         algo = PowAlgo::INVALID;
     }
@@ -272,6 +274,7 @@ public:
         hashMerkleRoot = block.hashMerkleRoot;
         nTime          = block.nTime;
         nBits          = block.pow.getBits();
+        nNonce         = block.nNonce;
 
         algo = block.pow.getCoreAlgo();
     }
@@ -426,6 +429,7 @@ public:
         READWRITE(hashMerkleRoot);
         READWRITE(nTime);
         READWRITE(nBits);
+        READWRITE(nNonce);
 
         READWRITE(algo);
     }
@@ -438,7 +442,7 @@ public:
         block.hashMerkleRoot  = hashMerkleRoot;
         block.nTime           = nTime;
         block.nBits           = 0;
-        block.nNonce          = 0;
+        block.nNonce          = nNonce;
         return block.GetHash();
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -161,6 +161,7 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
     result.pushKV("merkleroot", blockindex->hashMerkleRoot.GetHex());
     result.pushKV("time", (int64_t)blockindex->nTime);
     result.pushKV("mediantime", (int64_t)blockindex->GetMedianTimePast());
+    result.pushKV("nonce", (uint64_t)blockindex->nNonce);
     result.pushKV("chainwork", blockindex->nChainWork.GetHex());
     result.pushKV("nTx", (uint64_t)blockindex->nTx);
 
@@ -200,6 +201,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
     result.pushKV("tx", txs);
     result.pushKV("time", block.GetBlockTime());
     result.pushKV("mediantime", (int64_t)blockindex->GetMedianTimePast());
+    result.pushKV("nonce", (uint64_t)block.nNonce);
     result.pushKV("chainwork", blockindex->nChainWork.GetHex());
     result.pushKV("nTx", (uint64_t)blockindex->nTx);
 
@@ -801,6 +803,7 @@ static UniValue getblockheader(const JSONRPCRequest& request)
             "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
             "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
+            "  \"nonce\" : n,           (numeric) The nonce\n"
             "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
             "  \"nTx\" : n,             (numeric) The number of transactions in the block.\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
@@ -893,6 +896,7 @@ static UniValue getblock(const JSONRPCRequest& request)
             "  ],\n"
             "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
+            "  \"nonce\" : n,           (numeric) The nonce\n"
             "  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n"
             "  \"nTx\" : n,             (numeric) The number of transactions in the block.\n"
             "  \"powdata\" : {...},     (json object) The block's attached PoW data\n"

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -468,6 +468,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
                 pindexNew->nTime          = diskindex.nTime;
                 pindexNew->nBits          = diskindex.nBits;
+                pindexNew->nNonce         = diskindex.nNonce;
                 pindexNew->algo           = diskindex.algo;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;


### PR DESCRIPTION
After the post-ICO fork, `nNonce` values in blocks are allowed to be non-zero.  This is fine from a consensus point of view (and was tested), but it caused corruption to the on-disk block index.

The reason for this is that the `nNonce` value was not included in the `C(Disk)BlockIndex` instances, and was assumed to be zero when computing the block hash from a `CDiskBlockIndex` that is being loaded.  Thus blocks would be inserted into `mapBlockIndex` at a wrong hash, so that the `pprev` pointer of the next block (referring to the correct block index) was pointing to an empty struct instead.

This fix adds back `nNonce` to `C(Disk)BlockIndex`, so that all works fine.  Users who synced beyond the first affected block (529761 on mainnet).

See also #82.