### PR TITLE
Return HTTP_OK for RPC errors

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -69,19 +69,10 @@ static std::unique_ptr<HTTPRPCTimerInterface> httpRPCTimerInterface;
 
 static void JSONErrorReply(HTTPRequest* req, const UniValue& objError, const UniValue& id)
 {
-    // Send error reply from json-rpc error object
-    int nStatus = HTTP_INTERNAL_SERVER_ERROR;
-    int code = find_value(objError, "code").get_int();
-
-    if (code == RPC_INVALID_REQUEST)
-        nStatus = HTTP_BAD_REQUEST;
-    else if (code == RPC_METHOD_NOT_FOUND)
-        nStatus = HTTP_NOT_FOUND;
-
     std::string strReply = JSONRPCReply(NullUniValue, objError, id);
 
     req->WriteHeader("Content-Type", "application/json");
-    req->WriteReply(nStatus, strReply);
+    req->WriteReply(HTTP_OK, strReply);
 }
 
 //This function checks username and password against -rpcauth

--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -61,8 +61,8 @@ class RPCInterfaceTest(BitcoinTestFramework):
     def test_http_status_codes(self):
         self.log.info("Testing HTTP status codes for JSON-RPC requests...")
 
-        expect_http_status(404, -32601, self.nodes[0].invalidmethod)
-        expect_http_status(500, -8, self.nodes[0].getblockhash, 42)
+        expect_http_status(200, -32601, self.nodes[0].invalidmethod)
+        expect_http_status(200, -8, self.nodes[0].getblockhash, 42)
 
     def run_test(self):
         self.test_getrpcinfo()


### PR DESCRIPTION
Return `HTTP_OK` (code 200) also for JSON-RPC calls that fail on the RPC side.  This makes sense, since those have a separate error code anyway through JSON-RPC itself.  HTTP error codes should signify actual errors on the HTTP transport side.

Some JSON-RPC libraries make it hard or impossible to properly extract the JSON-RPC error code if HTTP returns non-200.  This change makes life easier with those (and makes everything in general more consistent).

See also the [discussion for upstream Bitcoin](https://github.com/bitcoin/bitcoin/pull/15381).