### PR TITLE
Pass spent inputs in the game notifications

### DIFF
--- a/doc/xaya/games.md
+++ b/doc/xaya/games.md
@@ -63,7 +63,8 @@ The game state must not depend on any other transactions,
 neither pure currency transactions nor name updates not referencing the game.
 Furthermore, the game engine must only take into account the actual move
 value from the name update, not any other data.  It may, however, also depend
-on [*currency outputs*](#currency) created in the same transaction.**
+on [*currency outputs*](#currency) created in the same transaction
+and the *spent inputs* (useful for [atomic trades](trading.md)).**
 
 In particular, games must also not include any newly registered names into
 the game state until those names have been referenced by a move associated

--- a/doc/xaya/interface.md
+++ b/doc/xaya/interface.md
@@ -75,6 +75,12 @@ The `DATA` part, finally, is a JSON object with the relevant information:
             "txid": TXID,
             "name": UPDATED-NAME,
             "move": MOVE,
+            "inputs":
+              [
+                {"txid": PREVID1, "vout": VOUT1},
+                {"txid": PREVID2, "vout": VOUT2},
+                ...
+              ],
             "out":
               {
                 ADDRESS1: AMOUNT1,
@@ -110,6 +116,10 @@ The placeholders have the following meaning:
 * **`MOVE`:**
   The actual [move data](games.md#moves), as it is given in `.g[GAMEID]`
   of the name update's value.
+* **`PREVID`n and `VOUT`n:**
+  Previous outputs spent by the move transaction.  This is mainly useful
+  for implementing certain types of [atomic trades](trading.md).
+  Note that this *includes the name input* being spent!
 * **`ADDRESS`n and `AMOUNT`n:**
   Xaya addresses and amounts that were transacted in the move transaction,
   as described in the model for

--- a/src/zmq/zmqgames.cpp
+++ b/src/zmq/zmqgames.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Xaya developers
+// Copyright (c) 2018-2019 The Xaya developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
@@ -147,6 +147,16 @@ TransactionData::TransactionData (const CTransaction& tx)
   UniValue tmpl(UniValue::VOBJ);
   tmpl.pushKV ("txid", tx.GetHash ().GetHex ());
   tmpl.pushKV ("name", name.substr (2));
+
+  UniValue inputs(UniValue::VARR);
+  for (const auto& in : tx.vin)
+    {
+      UniValue cur(UniValue::VOBJ);
+      cur.pushKV ("txid", in.prevout.hash.GetHex ());
+      cur.pushKV ("vout", static_cast<int> (in.prevout.n));
+      inputs.push_back (cur);
+    }
+  tmpl.pushKV ("inputs", inputs);
 
   std::map<std::string, CAmount> outAmounts;
   for (const auto& out : tx.vout)


### PR DESCRIPTION
Include the inputs spent by a move transaction in the game block update notifications.  This information can be used by games to implement [certain types of atomic trades](https://github.com/xaya/xaya/blob/master/doc/xaya/trading.md).

Fixes https://github.com/xaya/xaya/issues/84.