### PR TITLE
ZMQ notifications for pending moves

### DIFF
--- a/doc/xaya/interface.md
+++ b/doc/xaya/interface.md
@@ -327,3 +327,6 @@ it is re-added after a block detach), the following notification is sent
 
 `DATA` is a description of the move in the same form as in the `moves` array
 for [`game-block-attach` notifications](#attach-detach).
+
+**NOTE:**  Notifications about pending moves are *best-effort only* and
+cannot be relied upon under any circumstances!

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -481,6 +481,7 @@ void SetupServerArgs()
     gArgs.AddArg("-zmqpubrawblockhwm=<n>", strprintf("Set publish raw block outbound message high water mark (default: %d)", CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM), false, OptionsCategory::ZMQ);
     gArgs.AddArg("-zmqpubrawtxhwm=<n>", strprintf("Set publish raw transaction outbound message high water mark (default: %d)", CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM), false, OptionsCategory::ZMQ);
     gArgs.AddArg("-zmqpubgameblocks=<address>", "Enable publication of game data for block attach/detach events in <address>", false, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubgamepending=<address>", "Enable publication of pending game transactions in <address>", false, OptionsCategory::ZMQ);
     gArgs.AddArg("-trackgame=<game>", "Enable tracking of the listed game for the Xaya game interface", false, OptionsCategory::ZMQ);
 #else
     hidden_args.emplace_back("-zmqpubhashblock=<address>");
@@ -492,6 +493,7 @@ void SetupServerArgs()
     hidden_args.emplace_back("-zmqpubrawblockhwm=<n>");
     hidden_args.emplace_back("-zmqpubrawtxhwm=<n>");
     hidden_args.emplace_back("-zmqpubgameblocks=<address>");
+    hidden_args.emplace_back("-zmqpubgamepending=<address>");
     hidden_args.emplace_back("-trackgame=<game>");
 #endif
 

--- a/src/rpc/game.cpp
+++ b/src/rpc/game.cpp
@@ -25,6 +25,18 @@
 namespace
 {
 
+TrackedGames*
+GetTrackedGames ()
+{
+  if (g_zmq_notification_interface == nullptr)
+    throw JSONRPCError (RPC_MISC_ERROR, "ZMQ notifications are disabled");
+
+  auto* games = g_zmq_notification_interface->GetTrackedGames ();
+  assert (games != nullptr);
+
+  return games;
+}
+
 ZMQGameBlocksNotifier*
 GetGameBlocksNotifier ()
 {
@@ -368,18 +380,18 @@ trackedgames (const JSONRPCRequest& request)
 #if ENABLE_ZMQ
   RPCTypeCheck (request.params, {UniValue::VSTR, UniValue::VSTR});
 
-  auto* notifier = GetGameBlocksNotifier ();
+  auto* tracked = GetTrackedGames ();
 
   if (request.params.size () == 0)
-    return notifier->GetTrackedGames ();
+    return tracked->Get ();
 
   const std::string& cmd = request.params[0].get_str ();
   const std::string& gameid = request.params[1].get_str ();
 
   if (cmd == "add")
-    notifier->AddTrackedGame (gameid);
+    tracked->Add (gameid);
   else if (cmd == "remove")
-    notifier->RemoveTrackedGame (gameid);
+    tracked->Remove (gameid);
   else
     throw JSONRPCError (RPC_INVALID_PARAMETER,
                         "invalid command for trackedgames: " + cmd);

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -31,3 +31,8 @@ bool CZMQAbstractNotifier::NotifyBlockDetached(const CBlock& /*block*/)
 {
     return true;
 }
+
+bool CZMQAbstractNotifier::NotifyPendingTx(const CTransaction& transaction)
+{
+    return true;
+}

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -50,6 +50,11 @@ public:
     virtual bool NotifyBlockAttached(const CBlock& block);
     virtual bool NotifyBlockDetached(const CBlock& block);
 
+    /* Notification for transactions that are now pending (in the mempool).
+       The difference to NotifyTransaction is that the latter is called also
+       when transactions are confirmed.  */
+    virtual bool NotifyPendingTx(const CTransaction& transaction);
+
 protected:
     void *psocket;
     std::string type;

--- a/src/zmq/zmqgames.cpp
+++ b/src/zmq/zmqgames.cpp
@@ -24,6 +24,32 @@
 const char* ZMQGameBlocksNotifier::PREFIX_ATTACH = "game-block-attach";
 const char* ZMQGameBlocksNotifier::PREFIX_DETACH = "game-block-detach";
 
+UniValue
+TrackedGames::Get () const
+{
+  LOCK (cs);
+
+  UniValue res(UniValue::VARR);
+  for (const auto& g : games)
+    res.push_back (g);
+
+  return res;
+}
+
+void
+TrackedGames::Add (const std::string& game)
+{
+  LOCK (cs);
+  games.insert (game);
+}
+
+void
+TrackedGames::Remove (const std::string& game)
+{
+  LOCK (cs);
+  games.erase (game);
+}
+
 bool
 ZMQGameBlocksNotifier::SendMessage (const std::string& command,
                                     const UniValue& data)
@@ -270,39 +296,13 @@ ZMQGameBlocksNotifier::SendBlockNotifications (
 bool
 ZMQGameBlocksNotifier::NotifyBlockAttached (const CBlock& block)
 {
-  LOCK (csTrackedGames);
-  return SendBlockNotifications (trackedGames, PREFIX_ATTACH, "", block);
+  LOCK (trackedGames.cs);
+  return SendBlockNotifications (trackedGames.games, PREFIX_ATTACH, "", block);
 }
 
 bool
 ZMQGameBlocksNotifier::NotifyBlockDetached (const CBlock& block)
 {
-  LOCK (csTrackedGames);
-  return SendBlockNotifications (trackedGames, PREFIX_DETACH, "", block);
-}
-
-UniValue
-ZMQGameBlocksNotifier::GetTrackedGames () const
-{
-  LOCK (csTrackedGames);
-
-  UniValue res(UniValue::VARR);
-  for (const auto& g : trackedGames)
-    res.push_back (g);
-
-  return res;
-}
-
-void
-ZMQGameBlocksNotifier::AddTrackedGame (const std::string& game)
-{
-  LOCK (csTrackedGames);
-  trackedGames.insert (game);
-}
-
-void
-ZMQGameBlocksNotifier::RemoveTrackedGame (const std::string& game)
-{
-  LOCK (csTrackedGames);
-  trackedGames.erase (game);
+  LOCK (trackedGames.cs);
+  return SendBlockNotifications (trackedGames.games, PREFIX_DETACH, "", block);
 }

--- a/src/zmq/zmqgames.cpp
+++ b/src/zmq/zmqgames.cpp
@@ -51,8 +51,8 @@ TrackedGames::Remove (const std::string& game)
 }
 
 bool
-ZMQGameBlocksNotifier::SendMessage (const std::string& command,
-                                    const UniValue& data)
+ZMQGameNotifier::SendMessage (const std::string& command,
+                              const UniValue& data)
 {
   const std::string dataStr = data.write ();
   return CZMQAbstractPublishNotifier::SendMessage (

--- a/src/zmq/zmqgames.h
+++ b/src/zmq/zmqgames.h
@@ -50,18 +50,13 @@ public:
 };
 
 /**
- * ZMQ publisher that handles the attach/detach messages for the Xaya game
- * interface (https://github.com/xaya/Specs/blob/master/interface.md).
+ * Superclass for game ZMQ notifiers.  It references a list of tracked
+ * games and provides general utility methods common for all game notifiers.
  */
-class ZMQGameBlocksNotifier : public CZMQAbstractPublishNotifier
+class ZMQGameNotifier : public CZMQAbstractPublishNotifier
 {
 
-public:
-
-  static const char* PREFIX_ATTACH;
-  static const char* PREFIX_DETACH;
-
-private:
+protected:
 
   /** Reference to the list of tracked games.  */
   const TrackedGames& trackedGames;
@@ -73,13 +68,29 @@ private:
 
 public:
 
-  ZMQGameBlocksNotifier () = delete;
-  ZMQGameBlocksNotifier (const ZMQGameBlocksNotifier&) = delete;
-  void operator= (const ZMQGameBlocksNotifier&) = delete;
+  ZMQGameNotifier () = delete;
+  ZMQGameNotifier (const ZMQGameNotifier&) = delete;
+  void operator= (const ZMQGameNotifier&) = delete;
 
-  explicit ZMQGameBlocksNotifier (const TrackedGames& tg)
+  explicit ZMQGameNotifier (const TrackedGames& tg)
     : trackedGames(tg)
   {}
+
+};
+
+/**
+ * ZMQ publisher that handles the attach/detach messages for the Xaya game
+ * interface (see doc/xaya/interface.md).
+ */
+class ZMQGameBlocksNotifier : public ZMQGameNotifier
+{
+
+public:
+
+  static const char* PREFIX_ATTACH;
+  static const char* PREFIX_DETACH;
+
+  using ZMQGameNotifier::ZMQGameNotifier;
 
   /**
    * Sends the block attach or detach notifications.  They are essentially the

--- a/src/zmq/zmqgames.h
+++ b/src/zmq/zmqgames.h
@@ -14,6 +14,7 @@
 
 class CBlock;
 class CBlockIndex;
+class CTransaction;
 class UniValue;
 
 /**
@@ -31,6 +32,7 @@ private:
   mutable CCriticalSection cs;
 
   friend class ZMQGameBlocksNotifier;
+  friend class ZMQGamePendingNotifier;
 
 public:
 
@@ -103,6 +105,24 @@ public:
 
   bool NotifyBlockAttached (const CBlock& block) override;
   bool NotifyBlockDetached (const CBlock& block) override;
+
+};
+
+/**
+ * ZMQ publisher that handles notifications for pending moves.
+ */
+class ZMQGamePendingNotifier : public ZMQGameNotifier
+{
+
+private:
+
+  static const char* PREFIX_MOVE;
+
+public:
+
+  using ZMQGameNotifier::ZMQGameNotifier;
+
+  bool NotifyPendingTx (const CTransaction& tx) override;
 
 };
 

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -58,6 +58,13 @@ private:
 
     /** The tracked games for notifications.  */
     std::unique_ptr<TrackedGames> trackedGames;
+
+    /**
+     * Sends out a transaction notification (NotifyTransaction on all our
+     * notifiers).  This is called when adding to the mempool, when connecting
+     * a block and when disconnecting a block.
+     */
+    void NotifyTransaction(const CTransactionRef& ptx);
 };
 
 extern CZMQNotificationInterface* g_zmq_notification_interface;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -6,8 +6,11 @@
 #define BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 
 #include <validationinterface.h>
+#include <zmq/zmqgames.h>
+
 #include <string>
 #include <map>
+#include <memory>
 #include <list>
 
 class CBlockIndex;
@@ -22,6 +25,10 @@ public:
     std::list<const CZMQAbstractNotifier*> GetActiveNotifiers() const;
 
     static CZMQNotificationInterface* Create();
+
+    inline TrackedGames* GetTrackedGames() {
+        return trackedGames.get();
+    }
 
     inline ZMQGameBlocksNotifier* GetGameBlocksNotifier() {
         return gameBlocksNotifier;
@@ -48,6 +55,9 @@ private:
      * notifications for game_sendupdates.
      */
     ZMQGameBlocksNotifier* gameBlocksNotifier;
+
+    /** The tracked games for notifications.  */
+    std::unique_ptr<TrackedGames> trackedGames;
 };
 
 extern CZMQNotificationInterface* g_zmq_notification_interface;

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -64,7 +64,7 @@ class BitcoinTestMetaClass(type):
     those standards are violated, a ``TypeError`` is raised."""
 
     def __new__(cls, clsname, bases, dct):
-        if not clsname in ['BitcoinTestFramework', 'NameTestFramework']:
+        if not clsname in ['BitcoinTestFramework', 'NameTestFramework', 'XayaZmqTest']:
             if not ('run_test' in dct and 'set_test_params' in dct):
                 raise TypeError("BitcoinTestFramework subclasses must override "
                                 "'run_test' and 'set_test_params'")

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -273,6 +273,9 @@ def p2p_port(n):
 def rpc_port(n):
     return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
+def zmq_port(n):
+    return PORT_MIN + 2 * PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
+
 def rpc_url(datadir, i, rpchost=None):
     rpc_u, rpc_p = get_auth_cookie(datadir)
     host = '127.0.0.1'

--- a/test/functional/test_framework/xaya_zmq.py
+++ b/test/functional/test_framework/xaya_zmq.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Framework for Xaya ZMQ tests."""
+
+from .test_framework import (
+  BitcoinTestFramework,
+)
+from .util import (
+  assert_equal,
+)
+
+import codecs
+import json
+import struct
+
+
+class ZmqSubscriber:
+  """
+  Helper class that implements subscription to one of the game ZMQ
+  notifiers of Xaya Core.
+  """
+
+  def __init__ (self, ctx, addr, game):
+    self.sequence = {}
+    self.game = game
+    self.prefixes = []
+
+    import zmq
+    self.socket = ctx.socket (zmq.SUB)
+    self.socket.set (zmq.RCVTIMEO, 60000)
+    self.socket.connect (addr)
+
+  def subscribe (self, prefix):
+    import zmq
+    self.prefixes.append (prefix)
+    self.socket.setsockopt_string (zmq.SUBSCRIBE,
+                                   "%s json %s" % (prefix, self.game))
+
+  def receive (self):
+    topic, body, seq = self.socket.recv_multipart ()
+
+    topic = codecs.decode (topic, "ascii")
+    parts = topic.split (" ")
+    assert_equal (len (parts), 3)
+    assert_equal (parts[1], "json")
+    assert_equal (parts[2], self.game)
+    assert parts[0] in self.prefixes
+
+    # Sequence should be incremental for the full topic string.
+    seqNum = struct.unpack ("<I", seq)[-1]
+    if not topic in self.sequence:
+      self.sequence[topic] = 0
+    assert_equal (seqNum, self.sequence[topic])
+    self.sequence[topic] += 1
+
+    return topic, json.loads (codecs.decode (body, "ascii"))
+
+  def assertNoMessage (self):
+    import zmq
+    try:
+      _ = self.socket.recv (zmq.NOBLOCK)
+      raise AssertionError ("expected no more messages, but got one")
+    except zmq.error.Again:
+      pass
+
+
+class XayaZmqTest (BitcoinTestFramework):
+
+  def skip_test_if_missing_module (self):
+    self.skip_if_no_py3_zmq ()
+    self.skip_if_no_bitcoind_zmq ()
+
+  def run_test (self):
+    try:
+      import zmq
+      ctx = zmq.Context ()
+      self.log.info ("Created ZMQ context");
+      self.run_test_with_zmq (ctx)
+    finally:
+      self.log.debug ("Destroying ZMQ context")
+      ctx.destroy (linger=None)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -226,6 +226,7 @@ BASE_SCRIPTS = [
     'xaya_gameblocks.py',
     'xaya_postico_fork.py',
     'xaya_premine.py',
+    'xaya_trackedgames.py',
     'xaya_trading.py',
 ]
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -224,6 +224,7 @@ BASE_SCRIPTS = [
     # Xaya-specific tests
     'xaya_dualalgo.py',
     'xaya_gameblocks.py',
+    'xaya_gamepending.py',
     'xaya_postico_fork.py',
     'xaya_premine.py',
     'xaya_trackedgames.py',

--- a/test/functional/xaya_gameblocks.py
+++ b/test/functional/xaya_gameblocks.py
@@ -55,8 +55,7 @@ class GameBlocksTest (XayaZmqTest):
     args.append ("-zmqpubgameblocks=%s" % self.address)
     args.append ("-maxgameblockattaches=10")
     args.extend (["-trackgame=%s" % g for g in ["a", "b", "other"]])
-    self.extra_args = [args]
-    self.add_nodes (self.num_nodes, self.extra_args)
+    self.add_nodes (self.num_nodes, extra_args=[args])
     self.start_nodes ()
     self.import_deterministic_coinbase_privkeys ()
 
@@ -83,7 +82,6 @@ class GameBlocksTest (XayaZmqTest):
     self._test_reorg ()
     self._test_sendUpdates ()
     self._test_maxGameBlockAttaches ()
-    self._test_trackedgamesRPC ()
 
     # After all the real tests, verify no more notifications are there.
     # This especially verifies that the "ignored" game we are subscribed to
@@ -576,40 +574,6 @@ class GameBlocksTest (XayaZmqTest):
     })
     self.verifyDetach ("a", longAttachA)
     self.verifyAttach ("a", shortAttachA)
-
-  def _test_trackedgamesRPC (self):
-    """
-    Tests the trackedgames RPC, which can be used to read and modify
-    the list of tracked games dynamically.
-    """
-
-    self.log.info ("Testing the trackedgames RPC...")
-
-    # Test initial set as configured by the startup options.
-    assert_equal (set (self.node.trackedgames ()), set (["a", "b", "other"]))
-
-    # Remove some tracked (and non-tracked) games.
-    self.node.trackedgames ("remove", "b")
-    self.node.trackedgames ("remove", "not-there")
-    assert_equal (set (self.node.trackedgames ()), set (["a", "other"]))
-
-    # Add a game that was previously not tracked.
-    self.node.trackedgames ("add", "ignored")
-    self.node.trackedgames ("add", "a")
-    assert_equal (set (self.node.trackedgames ()),
-                  set (["a", "ignored", "other"]))
-
-    # Trigger an update to make sure the modified list is taken into account.
-    self.node.generate (1)
-    topic, _ = self.games["a"].receive ()
-    assert_equal (topic, "game-block-attach json a")
-    topic, _ = self.games["ignored"].receive ()
-    assert_equal (topic, "game-block-attach json ignored")
-
-    # Restore original setting.
-    self.node.trackedgames ("add", "b")
-    self.node.trackedgames ("remove", "ignored")
-    assert_equal (set (self.node.trackedgames ()), set (["a", "b", "other"]))
 
 
 if __name__ == '__main__':

--- a/test/functional/xaya_gamepending.py
+++ b/test/functional/xaya_gamepending.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Tests the "game-pending" ZMQ notifications."""
+
+from test_framework.util import (
+  assert_equal,
+  assert_greater_than,
+  zmq_port,
+)
+from test_framework.xaya_zmq import (
+  XayaZmqTest,
+  ZmqSubscriber,
+)
+
+import json
+
+
+def assertMove (obj, txid, name, move):
+  """
+  Utility method to assert the value of a move JSON without verifying
+  the "out" field (which is unpredictable due to the change output).
+  """
+
+  assert_equal (obj["txid"], txid)
+  assert_equal (obj["name"], name)
+  assert_equal (obj["move"], move)
+
+  # Inputs and outputs should be reported, but we do not care about the
+  # exact form for this test (this is verified in xaya_gameblocks.py in
+  # more detail).
+  assert "inputs" in obj
+  assert "out" in obj
+
+
+class GamePendingTest (XayaZmqTest):
+
+  def set_test_params (self):
+    self.num_nodes = 1
+
+  def setup_nodes (self):
+    self.address = "tcp://127.0.0.1:%d" % zmq_port (1)
+
+    args = []
+    args.append ("-zmqpubgamepending=%s" % self.address)
+    args.extend (["-trackgame=%s" % g for g in ["a", "b", "other"]])
+    self.add_nodes (self.num_nodes, extra_args=[args])
+    self.start_nodes ()
+    self.import_deterministic_coinbase_privkeys ()
+
+    self.node = self.nodes[0]
+
+  def run_test (self):
+    # Make the checks for BitcoinTestFramework subclasses happy.
+    super ().run_test ()
+
+  def run_test_with_zmq (self, ctx):
+    self.games = {}
+    for g in ["a", "b", "ignored"]:
+      self.games[g] = ZmqSubscriber (ctx, self.address, g)
+      self.games[g].subscribe ("game-pending-move")
+
+    self._test_currencyIgnored ()
+    self._test_register ()
+    self._test_notWhenMined ()
+    self._test_update ()
+    self._test_multipleGames ()
+    self._test_blockDetach (ctx)
+
+    # After all the real tests, verify no more notifications are there.
+    # This especially verifies that the "ignored" game we are subscribed to
+    # has no notifications (because it is not tracked by the daemon).
+    self.log.info ("Verifying that there are no unexpected messages...")
+    for _, sub in self.games.items ():
+      sub.assertNoMessage ()
+
+  def _test_currencyIgnored (self):
+    self.log.info ("Testing pure currency transaction...")
+
+    addr = self.node.getnewaddress ()
+    self.node.sendtoaddress (addr, 1.5)
+
+    for _, sub in self.games.items ():
+      sub.assertNoMessage ()
+
+    self.node.generate (1)
+
+  def _test_register (self):
+    self.log.info ("Registering names...")
+
+    txid = self.node.name_register ("p/x", json.dumps ({"g":{"a":42}}))
+    self.node.name_register ("p/y", json.dumps ({"g":{"other":False}}))
+
+    _, data = self.games["a"].receive ()
+    assertMove (data, txid, "x", 42)
+
+    self.node.generate (1)
+
+  def _test_notWhenMined (self):
+    self.log.info ("Verifying no notification when transactions are mined...")
+
+    txid = self.node.name_register ("p/z", json.dumps ({"g":{"b":100}}))
+
+    _, data = self.games["b"].receive ()
+    assertMove (data, txid, "z", 100)
+
+    self.node.generate (1)
+    self.games["b"].assertNoMessage ()
+
+  def _test_update (self):
+    self.log.info ("Updating names...")
+
+    txid = self.node.name_update ("p/x", json.dumps ({"g":{"b":"foo"}}))
+    self.node.name_update ("p/y", json.dumps ({"g":{"ignored":42}}))
+
+    _, data = self.games["b"].receive ()
+    assertMove (data, txid, "x", "foo")
+
+    self.node.generate (1)
+
+  def _test_multipleGames (self):
+    self.log.info ("Testing multiple games in one move...")
+
+    txid = self.node.name_update ("p/y", json.dumps ({
+      "g":
+        {
+          "a": 1,
+          "b": 2,
+          "ignored": 3,
+        }
+    }))
+
+    _, data = self.games["a"].receive ()
+    assertMove (data, txid, "y", 1)
+
+    _, data = self.games["b"].receive ()
+    assertMove (data, txid, "y", 2)
+
+    self.node.generate (1)
+
+  def _test_blockDetach (self, ctx):
+    self.log.info ("Testing block detach...")
+
+    # Enable also block notifications, so that we can test the relationship
+    # between pending tx and the block detach (the detach should come first).
+    # We use a new game ID here so that we do not mess up other tests.
+    args = []
+    args.append ("-zmqpubgameblocks=%s" % self.address)
+    args.append ("-zmqpubgamepending=%s" % self.address)
+    args.append ("-trackgame=detach")
+    self.restart_node (0, extra_args=args)
+
+    notifier = ZmqSubscriber (ctx, self.address, "detach")
+    notifier.subscribe ("game-pending-move")
+    notifier.subscribe ("game-block-detach")
+
+    self.node.generate (1)
+    txid = self.node.name_update ("p/x", json.dumps ({
+      "g": {"detach": "detached"}
+    }))
+
+    topic, data = notifier.receive ()
+    assert_equal (topic, "game-pending-move json detach")
+    assertMove (data, txid, "x", "detached")
+
+    blk = self.node.generate (1)[0]
+    self.node.invalidateblock (blk)
+
+    topic, data = notifier.receive ()
+    assert_equal (topic, "game-block-detach json detach")
+    assert_equal (data["block"]["hash"], blk)
+    assert_equal (len (data["moves"]), 1)
+    assertMove (data["moves"][0], txid, "x", "detached")
+
+    topic, data = notifier.receive ()
+    assert_equal (topic, "game-pending-move json detach")
+    assertMove (data, txid, "x", "detached")
+
+    notifier.assertNoMessage ()
+
+
+if __name__ == '__main__':
+    GamePendingTest ().main ()

--- a/test/functional/xaya_trackedgames.py
+++ b/test/functional/xaya_trackedgames.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Tests the "trackedgames" RPC command for game ZMQ notifications."""
+
+from test_framework.util import (
+  assert_equal,
+  zmq_port,
+)
+from test_framework.xaya_zmq import (
+  XayaZmqTest,
+  ZmqSubscriber,
+)
+
+
+class TrackedGamesTest (XayaZmqTest):
+
+  def set_test_params (self):
+    self.num_nodes = 1
+
+  def setup_nodes (self):
+    self.address = "tcp://127.0.0.1:%d" % zmq_port (1)
+
+    args = []
+    args.append ("-zmqpubgameblocks=%s" % self.address)
+    args.extend (["-trackgame=%s" % g for g in ["a", "b", "other"]])
+    self.add_nodes (self.num_nodes, extra_args=[args])
+    self.start_nodes ()
+
+    self.node = self.nodes[0]
+
+  def run_test (self):
+    # Make the checks for BitcoinTestFramework subclasses happy.
+    super ().run_test ()
+
+  def run_test_with_zmq (self, ctx):
+    games = {}
+    for g in ["a", "b", "ignored"]:
+      games[g] = ZmqSubscriber (ctx, self.address, g)
+      games[g].subscribe ("game-block-attach")
+      games[g].subscribe ("game-block-detach")
+
+    # Test initial set as configured by the startup options.
+    self.log.info ("Testing trackedgames...")
+    assert_equal (set (self.node.trackedgames ()), set (["a", "b", "other"]))
+
+    # Remove some tracked (and non-tracked) games.
+    self.node.trackedgames ("remove", "b")
+    self.node.trackedgames ("remove", "not-there")
+    assert_equal (set (self.node.trackedgames ()), set (["a", "other"]))
+
+    # Add a game that was previously not tracked.
+    self.node.trackedgames ("add", "ignored")
+    self.node.trackedgames ("add", "a")
+    assert_equal (set (self.node.trackedgames ()),
+                  set (["a", "ignored", "other"]))
+
+    # Trigger an update to make sure the modified list is taken into account.
+    self.node.generate (1)
+    topic, _ = games["a"].receive ()
+    assert_equal (topic, "game-block-attach json a")
+    topic, _ = games["ignored"].receive ()
+    assert_equal (topic, "game-block-attach json ignored")
+
+    # Restore original setting.
+    self.node.trackedgames ("add", "b")
+    self.node.trackedgames ("remove", "ignored")
+    assert_equal (set (self.node.trackedgames ()), set (["a", "b", "other"]))
+
+    # After all the real tests, verify no more notifications are there.
+    # This especially verifies that the "ignored" game we are subscribed to
+    # has no notifications (because it is not tracked by the daemon).
+    self.log.info ("Verifying that there are no unexpected messages...")
+    for _, sub in games.items ():
+      sub.assertNoMessage ()
+
+    # Restart the node without any active ZMQ notifications.  The tracked games
+    # should still work fine.
+    self.log.info ("Testing without game ZMQ notifications...")
+    args = ["-trackgame=a", "-zmqpubhashblock=%s" % self.address]
+    self.restart_node (0, extra_args=args)
+    self.node.trackedgames ("add", "b")
+    assert_equal (set (self.node.trackedgames ()), set (["a", "b"]))
+    game = ZmqSubscriber (ctx, self.address, "a")
+    game.subscribe ("game-block-attach")
+    self.node.generate (1)
+    game.assertNoMessage ()
+
+
+if __name__ == '__main__':
+    TrackedGamesTest ().main ()


### PR DESCRIPTION
This adds a new ZMQ notifier (enabled with `-zmqpubgamepending`), which sends out notifications per tracked game for pending moves as they are added to the mempool (including when they are readded for disconnected blocks, but not including notifications for confirmed transactions).
    
This has been long described in [`doc/xaya/interface.md`](https://github.com/xaya/xaya/blob/master/doc/xaya/interface.md#pending-moves), but not yet implemented.  Fixes #54.

This is a copy of #90, which I messed up during merging.