### PR TITLE
Extend admin command format in ZMQ notifications

### DIFF
--- a/doc/xaya/interface.md
+++ b/doc/xaya/interface.md
@@ -68,7 +68,7 @@ The `DATA` part, finally, is a JSON object with the relevant information:
           "timestamp": BLOCK-TIME,
           "rngseed": RNG-SEED,
         },
-      "cmd": ADMIN-COMMAND,
+      "admin": ADMIN-COMMANDS,
       "moves":
         [
           {
@@ -103,10 +103,6 @@ The placeholders have the following meaning:
 * **`RNG-SEED`, `BLOCK-HEIGHT` and `BLOCK-TIME`:**
   Additional data about the attached block, which might be used by the game
   engine in the update logic.
-* **`ADMIN-COMMAND`:**
-  If the block contains an update the name game's `g/` name, then this
-  field is set to the game-specific [*admin command*](games.md#games)
-  specified with that update.
 * **`TXID`:**
   The Xaya transaction ID of the transaction that performed the given move.
   This is mostly useful as a key and to correlate a single transaction
@@ -124,6 +120,26 @@ The placeholders have the following meaning:
   Xaya addresses and amounts that were transacted in the move transaction,
   as described in the model for
   [currency transaction in games](games.md#currency).
+
+If the block contains an update to the game's `g/` name, then these
+[*admin commands*](games.md#games) are returned in `ADMIN-COMMANDS`.
+This value is a JSON array of zero, one or more elements, where each
+element is a JSON object of the following form corresponding to one update
+of the `g/` name:
+
+    {
+      "txid": TXID,
+      "cmd": COMMAND,
+    }
+
+Here, `TXID` is the transaction ID of the name update, and `COMMAND` is the
+game-specific value sent as admin command through the transaction.
+Note that Xaya typically allows a single name to be updated only once per block,
+but this is a restriction *purely on the mempool and policy side*.  On the
+consensus layer, it is perfectly fine to have more than one update in a block.
+Thus, it is not impossible to have more than one admin command!
+Most of the time, though, `ADMIN-COMMANDS` will have either zero
+or one element.
 
 Note that not all transactions from the block are included in the `moves` list.
 It contains only those that are relevant for the current game, which are

--- a/src/zmq/zmqgames.cpp
+++ b/src/zmq/zmqgames.cpp
@@ -224,14 +224,17 @@ ZMQGameBlocksNotifier::SendBlockNotifications (
     const std::set<std::string>& games, const std::string& commandPrefix,
     const std::string& reqtoken, const CBlock& block)
 {
-  /* Start with an empty array of moves for each game that we track.  */
+  /* Start with an empty array of moves and commands for each game.  */
   std::map<std::string, UniValue> perGameMoves;
-  for (const auto& game : games)
-    perGameMoves[game] = UniValue (UniValue::VARR);
   std::map<std::string, UniValue> perGameAdminCmds;
+  for (const auto& game : games)
+    {
+      perGameMoves[game] = UniValue (UniValue::VARR);
+      perGameAdminCmds[game] = UniValue (UniValue::VARR);
+    }
 
-  /* Add relevant moves for each game from all the transactions.  Also keep
-     track of the admin commands for each game, if there are any.  */
+  /* Add relevant moves and admin commands for each game from all the
+     transactions to our arrays.  */
   for (const auto& tx : block.vtx)
     {
       const TransactionData data(*tx);
@@ -249,11 +252,20 @@ ZMQGameBlocksNotifier::SendBlockNotifications (
 
       std::string adminGame;
       UniValue adminCmd;
-      if (data.IsAdminCommand (adminGame, adminCmd)
-            && games.count (adminGame) > 0)
+      if (data.IsAdminCommand (adminGame, adminCmd))
         {
-          assert (perGameAdminCmds.count (adminGame) == 0);
-          perGameAdminCmds.emplace (adminGame, adminCmd);
+          auto mit = perGameAdminCmds.find (adminGame);
+          if (mit == perGameAdminCmds.end ())
+            continue;
+
+          assert (games.count (adminGame) > 0);
+          assert (mit->second.isArray ());
+
+          UniValue cmd(UniValue::VOBJ);
+          cmd.pushKV ("txid", tx->GetHash ().GetHex ());
+          cmd.pushKV ("cmd", adminCmd);
+
+          mit->second.push_back (cmd);
         }
     }
 
@@ -278,16 +290,17 @@ ZMQGameBlocksNotifier::SendBlockNotifications (
      template object.  */
   for (const auto& game : games)
     {
-      auto mit = perGameMoves.find (game);
-      assert (mit != perGameMoves.end ());
-      assert (mit->second.isArray ());
+      auto mitMv = perGameMoves.find (game);
+      assert (mitMv != perGameMoves.end ());
+      assert (mitMv->second.isArray ());
+
+      auto mitCmd = perGameAdminCmds.find (game);
+      assert (mitCmd != perGameAdminCmds.end ());
+      assert (mitCmd->second.isArray ());
 
       UniValue data = tmpl;
-      data.pushKV ("moves", mit->second);
-
-      auto adminCmd = perGameAdminCmds.find (game);
-      if (adminCmd != perGameAdminCmds.end ())
-        data.pushKV ("cmd", adminCmd->second);
+      data.pushKV ("moves", mitMv->second);
+      data.pushKV ("admin", mitCmd->second);
 
       if (!SendMessage (commandPrefix + " json " + game, data))
         return false;


### PR DESCRIPTION
With this, we change the format of admin commands in the ZMQ block notifications to an array of objects.  That format is more flexible and future-proof, as we can add more fields as needed.  Also by having it an array, we make sure that multiple updates of a `g/` name in one block are handled properly (#89).  This is something that is not easily possible, but can happen in theory if blocks are constructed directly.