### PR TITLE
Backport:  Extended admin command format

### DIFF
--- a/doc/xaya/interface.md
+++ b/doc/xaya/interface.md
@@ -68,7 +68,7 @@ The `DATA` part, finally, is a JSON object with the relevant information:
           "timestamp": BLOCK-TIME,
           "rngseed": RNG-SEED,
         },
-      "cmd": ADMIN-COMMAND,
+      "admin": ADMIN-COMMANDS,
       "moves":
         [
           {
@@ -103,10 +103,6 @@ The placeholders have the following meaning:
 * **`RNG-SEED`, `BLOCK-HEIGHT` and `BLOCK-TIME`:**
   Additional data about the attached block, which might be used by the game
   engine in the update logic.
-* **`ADMIN-COMMAND`:**
-  If the block contains an update the name game's `g/` name, then this
-  field is set to the game-specific [*admin command*](games.md#games)
-  specified with that update.
 * **`TXID`:**
   The Xaya transaction ID of the transaction that performed the given move.
   This is mostly useful as a key and to correlate a single transaction
@@ -124,6 +120,26 @@ The placeholders have the following meaning:
   Xaya addresses and amounts that were transacted in the move transaction,
   as described in the model for
   [currency transaction in games](games.md#currency).
+
+If the block contains an update to the game's `g/` name, then these
+[*admin commands*](games.md#games) are returned in `ADMIN-COMMANDS`.
+This value is a JSON array of zero, one or more elements, where each
+element is a JSON object of the following form corresponding to one update
+of the `g/` name:
+
+    {
+      "txid": TXID,
+      "cmd": COMMAND,
+    }
+
+Here, `TXID` is the transaction ID of the name update, and `COMMAND` is the
+game-specific value sent as admin command through the transaction.
+Note that Xaya typically allows a single name to be updated only once per block,
+but this is a restriction *purely on the mempool and policy side*.  On the
+consensus layer, it is perfectly fine to have more than one update in a block.
+Thus, it is not impossible to have more than one admin command!
+Most of the time, though, `ADMIN-COMMANDS` will have either zero
+or one element.
 
 Note that not all transactions from the block are included in the `moves` list.
 It contains only those that are relevant for the current game, which are

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -644,7 +644,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
     }
 
     if (!pool.checkNameOps(tx))
-        return false;
+        return state.Invalid(false, REJECT_DUPLICATE, "txn-mempool-name-error");
 
     {
         CCoinsView dummy;

--- a/test/functional/name_multiupdate.py
+++ b/test/functional/name_multiupdate.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Daniel Kraft
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests the behaviour of multiple updates for one name within a single block.
+
+from test_framework.names import NameTestFramework, val, buildMultiUpdateBlock
+
+from test_framework.util import (
+  assert_equal,
+  assert_raises_rpc_error,
+)
+
+
+class NameMultiUpdateTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_clean_chain = True
+    self.setup_name_test ([["-debug", "-namehistory"]] * 1)
+
+  def run_test (self):
+    self.node = self.nodes[0]
+    self.node.generate (110)
+
+    # Register a test name.
+    name = "d/test"
+    self.node.name_register (name, val ("first"))
+    self.node.generate (1)
+    self.checkName (0, name, val ("first"))
+
+    # Update the name (keep the transaction pending) and check that another
+    # update is not allowed by the mempool.
+    txid = self.node.name_update (name, val ("second"))
+    assert_raises_rpc_error (-25, "already a pending update",
+                             self.node.name_update, name, val ("wrong"))
+    self.node.generate (1)
+    self.checkName (0, name, val ("second"))
+
+    # Build two update transactions building on each other and try to
+    # submit them both as transactions.
+    blk = buildMultiUpdateBlock (self.node, name, val (["third", "wrong"]))
+    assert_equal (len (blk.vtx), 3)
+    self.node.sendrawtransaction (blk.vtx[1].serialize ().hex ())
+    assert_raises_rpc_error (-26, "txn-mempool-name-error",
+                             self.node.sendrawtransaction,
+                             blk.vtx[2].serialize ().hex ())
+    self.node.generate (1)
+    self.checkName (0, name, val ("third"))
+
+    # Submitting two updates at once in a block is fine as long as that does
+    # not go through the mempool.
+    blk = buildMultiUpdateBlock (self.node, name, val (["fourth", "fifth"]))
+    assert_equal (self.node.submitblock (blk.serialize ().hex ()), None)
+
+    # Verify that the second update took effect, as well as the entire
+    # history of the name.
+    self.checkName (0, name, val ("fifth"))
+    values = [h["value"] for h in self.node.name_history (name)]
+    assert_equal (values, val (["first", "second", "third", "fourth", "fifth"]))
+
+
+if __name__ == '__main__':
+  NameMultiUpdateTest ().main ()

--- a/test/functional/run_name_tests.sh
+++ b/test/functional/run_name_tests.sh
@@ -18,6 +18,9 @@ echo "\nName listunspent..."
 echo "\nName multisig..."
 ./name_multisig.py
 
+echo "\nName multiupdates..."
+./name_multiupdate.py
+
 echo "\nName pending..."
 ./name_pending.py
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -210,6 +210,7 @@ BASE_SCRIPTS = [
     'name_listunspent.py',
     'name_multisig.py',
     'name_multisig.py --bip16-active',
+    'name_multiupdate.py',
     'name_pending.py',
     'name_rawtx.py',
     'name_registration.py',

--- a/test/functional/xaya_gameblocks.py
+++ b/test/functional/xaya_gameblocks.py
@@ -12,6 +12,7 @@ from test_framework.messages import (
   CTxIn,
   CTxOut,
 )
+from test_framework.names import buildMultiUpdateBlock
 from test_framework.util import (
   assert_equal,
   assert_greater_than,
@@ -146,7 +147,8 @@ class GameBlocksTest (XayaZmqTest):
           "timestamp": data['time'],
           "rngseed": data['rngseed'],
         },
-      "moves": []
+      "admin": [],
+      "moves": [],
     }
 
     for g in ["a", "b"]:
@@ -187,6 +189,23 @@ class GameBlocksTest (XayaZmqTest):
     assert_equal (len (data["moves"]), 2)
     assertMove (data["moves"][indX], txidX, "x", {"test": True})
     assertMove (data["moves"][indY], txidY, "y", 6.25)
+
+    # Construct two updates of a single name in one block, to verify that
+    # edge case is also handled correctly.
+    blk = buildMultiUpdateBlock (self.node, "p/x", [
+      json.dumps ({"g": {"a": 1, "b": 2}}),
+      json.dumps ({"g": {"a": 3}}),
+    ])
+    assert_equal (self.node.submitblock (blk.serialize ().hex ()), None)
+
+    _, data = self.games["a"].receive ()
+    assert_equal (len (data["moves"]), 2)
+    assertMove (data["moves"][0], blk.vtx[1].hash, "x", 1)
+    assertMove (data["moves"][1], blk.vtx[2].hash, "x", 3)
+
+    _, data = self.games["b"].receive ()
+    assert_equal (len (data["moves"]), 1)
+    assertMove (data["moves"][0], blk.vtx[1].hash, "x", 2)
 
   def _test_inputs (self):
     """
@@ -283,29 +302,52 @@ class GameBlocksTest (XayaZmqTest):
     for g in ["a", "b"]:
       _, data = self.games[g].receive ()
       assert_equal (data["moves"], [])
-      assert "cmd" not in data
+      assert_equal (data["admin"], [])
 
     # Now actually issue admin commands together with a move.  One of the
     # g/ names is updated, the other registered.  This makes sure that both
-    # work as expected.
-    self.node.name_update ("g/a", json.dumps ({
+    # work as expected.  Also send a command for a non-tracked game.
+    txidCmdA = self.node.name_update ("g/a", json.dumps ({
       "stuff": "ignored",
       "cmd": 42,
     }))
-    self.node.name_register ("g/b", json.dumps ({
+    txidCmdB = self.node.name_register ("g/b", json.dumps ({
       "cmd": {"foo": "bar"},
     }))
-    txid = self.node.name_update ("p/x", json.dumps ({"g":{"a":True}}))
+    self.node.name_register ("g/ignored", json.dumps ({
+      "cmd": "this game is not tracked",
+    }))
+    txidMvA = self.node.name_update ("p/x", json.dumps ({"g":{"a":True}}))
     self.node.generate (1)
 
     _, data = self.games["a"].receive ()
     assert_equal (len (data["moves"]), 1)
-    assertMove (data["moves"][0], txid, "x", True)
-    assert_equal (data["cmd"], 42)
+    assertMove (data["moves"][0], txidMvA, "x", True)
+    assert_equal (data["admin"], [{"txid": txidCmdA, "cmd": 42}])
 
     _, data = self.games["b"].receive ()
     assert_equal (data["moves"], [])
-    assert_equal (data["cmd"], {"foo": "bar"})
+    assert_equal (data["admin"], [{"txid": txidCmdB, "cmd": {"foo": "bar"}}])
+
+    # Do two admin commands of one game in a single block.  This is not possible
+    # with ordinary commands, as the mempool policy forbids it.  It is valid
+    # if a block is constructed directly, though.
+    blk = buildMultiUpdateBlock (self.node, "g/a", [
+      json.dumps ({"cmd": "first"}),
+      json.dumps ({"cmd": "second"}),
+    ])
+    assert_equal (self.node.submitblock (blk.serialize ().hex ()), None)
+
+    _, data = self.games["a"].receive ()
+    assert_equal (data["moves"], [])
+    assert_equal (data["admin"], [
+      {"txid": blk.vtx[1].hash, "cmd": "first"},
+      {"txid": blk.vtx[2].hash, "cmd": "second"},
+    ])
+
+    _, data = self.games["b"].receive ()
+    assert_equal (data["moves"], [])
+    assert_equal (data["admin"], [])
 
   def buildChain (self, n):
     """


### PR DESCRIPTION
This is a backport of #93 (and including https://github.com/namecoin/namecoin-core/pull/299) to the `1.2` branch, so that the fix of #89 will be included in the upcoming `1.2` release as well.