### PR TITLE
Do not install libnamecoinconsensus

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ export PYTHONPATH
 
 if BUILD_BITCOIN_LIBS
 pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = libnamecoinconsensus.pc
+noinst_DATA = libnamecoinconsensus.pc
 endif
 
 BITCOIND_BIN=$(top_builddir)/src/$(BITCOIN_DAEMON_NAME)$(EXEEXT)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,7 +74,7 @@ EXTRA_LIBRARIES += \
   $(LIBBITCOIN_WALLET_TOOL) \
   $(LIBBITCOIN_ZMQ)
 
-lib_LTLIBRARIES = $(LIBBITCOINCONSENSUS)
+noinst_LTLIBRARIES = $(LIBBITCOINCONSENSUS)
 
 bin_PROGRAMS =
 noinst_PROGRAMS = xaya-hash
@@ -657,7 +657,7 @@ xaya_wallet_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(CRYPTO_LIBS) $(EVENT_PTHREADS_L
 
 # bitcoinconsensus library #
 if BUILD_BITCOIN_LIBS
-include_HEADERS = script/namecoinconsensus.h
+noinst_HEADERS = script/namecoinconsensus.h
 libnamecoinconsensus_la_SOURCES = $(crypto_libbitcoin_crypto_base_a_SOURCES) $(libbitcoin_consensus_a_SOURCES)
 
 if GLIBC_BACK_COMPAT


### PR DESCRIPTION
With this change, we disable installation of `libnamecoinconsensus` when `make install` is done for Xaya.  The library has not been rebranded, so that this would conflict with an installation of Namecoin on the same system.  Since the library is not used anywhere, this is also no loss of functionality (but once it is needed, it can be properly rebranded and installation re-enabled).

After this change, only the manpages are still conflicting with Namecoin and Bitcoin during installation.  This is an upstream issue with Namecoin, and will be fixed there first.