### PR TITLE
Properly handle duplicated JSON keys

### DIFF
--- a/test/functional/xaya_gamepending.py
+++ b/test/functional/xaya_gamepending.py
@@ -67,6 +67,7 @@ class GamePendingTest (XayaZmqTest):
     self._test_notWhenMined ()
     self._test_update ()
     self._test_multipleGames ()
+    self._test_duplicateKeys ()
     self._test_blockDetach (ctx)
 
     # After all the real tests, verify no more notifications are there.
@@ -137,6 +138,36 @@ class GamePendingTest (XayaZmqTest):
 
     _, data = self.games["b"].receive ()
     assertMove (data, txid, "y", 2)
+
+    self.node.generate (1)
+
+  def _test_duplicateKeys (self):
+    self.log.info ("Testing duplicate JSON keys...")
+
+    mv = """
+      {
+        "g":
+          {
+            "a": "a1"
+          },
+        "g":
+          {
+            "a": "a2",
+            "b": "b1"
+          },
+        "g":
+          {
+            "b": "b2"
+          }
+      }
+    """
+    txid = self.node.name_update ("p/x", mv, {"valueEncoding": "utf8"})
+
+    _, data = self.games["a"].receive ()
+    assertMove (data, txid, "x", "a2")
+
+    _, data = self.games["b"].receive ()
+    assertMove (data, txid, "x", "b2")
 
     self.node.generate (1)
 


### PR DESCRIPTION
Xaya Core does some non-trivial processing of JSON values, namely when determining what ZMQ notifications to send out for blocks and pending transactions.

JSON allows duplicated keys in objects, which is an edge case that has not been considered very well before.  With this update, we explicitly handle it and specify what behaviour Xaya Core should have in tests and the documentation.

In particular, if a `name_update` has duplicate `g` or `cmd` fields, then we now process all of them.  If a single game ID is given multiple times (because of duplicated `g` fields, or because it is a duplicated key itself within a `g`), then we dedup that and only keep the last value.

Only sending one move for a single game (rather than multiple ones) makes sense, because this avoids a situation where e.g. a single CHI payment could be seen by a game in two moves and might be interpreted as if CHI was paid twice by a carelessly implemented GSP.  We use the last rather than first game, because this matches typical behaviour of libraries that do not support duplicate keys explicitly; examples are Python's json standard package and the [JsonCpp library](https://github.com/open-source-parsers/jsoncpp) used in [libxayagame](https://github.com/xaya/libxayagame).

Note that this is a change compared to previous versions, where we were only interpreting the first of duplicated fields.  Hence, updating Xaya Core with this change forks game worlds (but not the Xaya network).  In practice, this is not an issue yet, as there are no important mainnet game worlds out there at the moment.