### PR TITLE
Support CHI burns for moves

### DIFF
--- a/doc/xaya/games.md
+++ b/doc/xaya/games.md
@@ -217,6 +217,14 @@ Note that there exists a second possibility for trading in games:
 This is particularly useful for market places between players themselves,
 rather than payments to a game developer.
 
+An alternative to handling CHI payments is to require **burning of CHI**.
+This can be used to create a cost for certain actions (e.g. to discourage
+spamming them), while not creating a privileged instance (the receiver
+of payments).  To burn CHI in relation to a given move in a game,
+they should be sent to an `OP_RETURN` output with `g/GAMEID` as the data
+part.  (The burn must be related uniquely to a specific game, since otherwise
+a single burn of CHI could be used for multiple games at the same time.)
+
 ## Processing Backwards in Time <a name="undoing"></a>
 
 While the typical behaviour of the Xaya blockchain is to attach blocks

--- a/doc/xaya/interface.md
+++ b/doc/xaya/interface.md
@@ -88,6 +88,7 @@ The `DATA` part, finally, is a JSON object with the relevant information:
                 ADDRESS2: AMOUNT2,
                 ...
               },
+            "burnt": BURNT,
           },
           ...
         ],
@@ -121,6 +122,9 @@ The placeholders have the following meaning:
   Xaya addresses and amounts that were transacted in the move transaction,
   as described in the model for
   [currency transaction in games](games.md#currency).
+* **`BURNT`:**
+  The total amount of CHI burnt in this transaction with data `g/GAMEID`
+  (i.e. "for the current game").
 
 If the block contains an update to the game's `g/` name, then these
 [*admin commands*](games.md#games) are returned in `ADMIN-COMMANDS`.

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -128,11 +128,9 @@ bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, const CFeeR
         }
     }
 
-    // only one OP_RETURN txout is permitted
-    if (nDataOut > 1) {
-        reason = "multi-op-return";
-        return false;
-    }
+    /* Upstream disallows more than one OP_RETURN output in a single
+       transaction, but Xaya allows this to enable combined moves with burns
+       for multiple games.  */
 
     return true;
 }

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -354,6 +354,9 @@ NameOptionsHelp::withWriteOptions ()
   withArg ("sendCoins", RPCArg::Type::OBJ_USER_KEYS,
            "Addresses to which coins should be sent additionally");
 
+  withArg ("burn", RPCArg::Type::OBJ_USER_KEYS,
+           "Data and amounts of CHI to burn in the transaction");
+
   return *this;
 }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -788,25 +788,13 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 
-    // Only one TX_NULL_DATA permitted in all cases
+    /* Unlike upstream, Xaya allows multiple OP_RETURN outputs in a single
+       transaction.  */
     t.vout.resize(2);
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
     t.vout[1].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
     reason.clear();
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
-    BOOST_CHECK_EQUAL(reason, "multi-op-return");
-
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
-    t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    reason.clear();
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
-    BOOST_CHECK_EQUAL(reason, "multi-op-return");
-
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN;
-    t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    reason.clear();
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
-    BOOST_CHECK_EQUAL(reason, "multi-op-return");
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 
     // Check large scriptSig (non-standard if size is >1650 bytes)
     t.vout.resize(1);

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -288,13 +288,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'dust'}],
             rawtxs=[tx.serialize().hex()],
         )
-        tx.deserialize(BytesIO(hex_str_to_bytes(raw_tx_reference)))
-        tx.vout[0].scriptPubKey = CScript([OP_RETURN, b'\xff'])
-        tx.vout = [tx.vout[0]] * 2
-        self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'multi-op-return'}],
-            rawtxs=[tx.serialize().hex()],
-        )
+        # Unlike upstream, Xaya allows multiple OP_RETURN outputs.  So no test for this.
 
         self.log.info('A timelocked transaction')
         tx.deserialize(BytesIO(hex_str_to_bytes(raw_tx_reference)))

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -246,6 +246,7 @@ BASE_SCRIPTS = [
     'name_wallet.py',
 
     # Xaya-specific tests
+    'xaya_create_burns.py',
     'xaya_dualalgo.py',
     'xaya_gameblocks.py',
     'xaya_gamepending.py',

--- a/test/functional/xaya_create_burns.py
+++ b/test/functional/xaya_create_burns.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Xaya developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""RPC test for the "burn" option of name operations."""
+
+from test_framework.names import NameTestFramework, val
+from test_framework.util import *
+
+import codecs
+
+# Maximum data length.
+MAX_DATA_LEN = 80
+
+
+class XayaCreateBurnsTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_name_test ([["-debug"]] * 1)
+
+  def verifyTx (self, txid, expected):
+    """Verify that the given tx burns coins with the expected data keys."""
+
+    txData = self.nodes[0].gettransaction (txid)
+    assert_greater_than (txData["confirmations"], 0)
+
+    tx = self.nodes[0].decoderawtransaction (txData["hex"])
+    vout = tx['vout']
+
+    # There should be two additional outputs: name and change
+    assert_equal (len (vout), len (expected) + 2)
+
+    actual = {}
+    for out in vout:
+      if out["scriptPubKey"]["type"] != "nulldata":
+        continue
+
+      prefix = "OP_RETURN "
+      asm = out["scriptPubKey"]["asm"]
+      assert asm.startswith (prefix)
+
+      # Small data may be encoded as integer in the asm string (rather than
+      # hex), but we assume this never happens.
+      hexNum = asm[len (prefix):]
+      data = codecs.decode (hexNum, "hex")
+      data = codecs.decode (data, "ascii")
+
+      actual[data] = out["value"]
+
+    assert_equal (actual, expected)
+
+  def run_test (self):
+
+    # Send name_register with burn and verify it worked as expected.
+    burn = {"foobar": 1, "baz baz baz": 2}
+    txid = self.nodes[0].name_register ("x/testname", val ("value"),
+                                        {"burn": burn})
+    self.nodes[0].generate (1)
+    self.verifyTx (txid, burn)
+
+    # Test different variations (numbers of burns) with name_update.
+    for n in range (5):
+      burn = {"foo %d" % i: 42 + i for i in range (n)}
+      txid = self.nodes[0].name_update ("x/testname", val ("value"),
+                                       {"burn": burn})
+      self.nodes[0].generate (1)
+      self.verifyTx (txid, burn)
+
+    # Test maximum length.
+    burn = {"a" * MAX_DATA_LEN: 1, "b" * MAX_DATA_LEN: 2}
+    txid = self.nodes[0].name_update ("x/testname", val ("value"),
+                                     {"burn": burn})
+    self.nodes[0].generate (1)
+    self.verifyTx (txid, burn)
+
+    # Verify the range check for amount and the data length verification.
+    assert_raises_rpc_error (-3, 'Invalid amount for burn',
+                             self.nodes[0].name_update,
+                             "x/testname", val ("value"),
+                             {"burn": {"foo": 0}})
+    assert_raises_rpc_error (-5, 'Burn data is too long',
+                             self.nodes[0].name_update,
+                             "x/testname", val ("value"),
+                             {"burn": {"x" * (MAX_DATA_LEN + 1): 1}})
+
+    # Verify the insufficient funds check, both where it fails a priori
+    # and where we just don't have enough for the fee.
+    balance = self.nodes[0].getbalance ()
+    assert_raises_rpc_error (-6, 'Insufficient funds',
+                             self.nodes[0].name_update,
+                             "x/testname", val ("value"),
+                             {"burn": {"x": balance + 1}})
+    assert_raises_rpc_error (-4, 'requires a transaction fee',
+                             self.nodes[0].name_update,
+                             "x/testname", val ("value"),
+                             {"burn": {"x": balance}})
+
+    # Check that we can send a name_update that burns almost all funds in
+    # the wallet.  We only need to keep a tiny amount to pay for the fee
+    # (but less than the locked amount of 0.01).
+    keep = Decimal ("0.009")
+    burn = {"some burn data": balance - keep}
+    txid = self.nodes[0].name_update ("x/testname", val ("value"),
+                                      {"burn": burn})
+    self.nodes[0].generate (1)
+    self.verifyTx (txid, burn)
+
+
+if __name__ == '__main__':
+  XayaCreateBurnsTest ().main ()

--- a/test/functional/xaya_gamepending.py
+++ b/test/functional/xaya_gamepending.py
@@ -66,6 +66,7 @@ class GamePendingTest (XayaZmqTest):
     self._test_register ()
     self._test_notWhenMined ()
     self._test_update ()
+    self._test_sendAndBurn ()
     self._test_multipleGames ()
     self._test_duplicateKeys ()
     self._test_blockDetach (ctx)
@@ -118,6 +119,25 @@ class GamePendingTest (XayaZmqTest):
 
     _, data = self.games["b"].receive ()
     assertMove (data, txid, "x", "foo")
+
+    self.node.generate (1)
+
+  def _test_sendAndBurn (self):
+    self.log.info ("Sending and burning CHI...")
+
+    addr = self.node.getnewaddress ()
+    opt = {
+      "sendCoins": {addr: 1},
+      "burn": {"g/a": 2, "g/b": 3, "ignored": 0.5},
+    }
+    txid = self.node.name_update ("p/x", json.dumps ({"g": {"a": "foo"}}), opt)
+
+    _, data = self.games["a"].receive ()
+    assertMove (data, txid, "x", "foo")
+
+    assert_equal (len (data["out"]), 2)
+    assert_equal (data["out"][addr], 1)
+    assert_equal (data["burnt"], 2)
 
     self.node.generate (1)
 


### PR DESCRIPTION
This implements #102.  In particular, there are three parts:

1. In contrast to upstream, we allow transactions with multiple `OP_RETURN` outputs as standard transactions.  This allows sending combined moves for multiple games with burns for each game.
2. The `options` argument for `name_register` and `name_update` now supports a `burn` field, which can be used (similar to `sendCoins`) to include coin burns in the transaction.
3. Data about burnt CHI is passed to games with block and pending ZMQ notifications.