### PR TITLE
Switch default value encoding to UTF-8

### DIFF
--- a/src/names/encoding.h
+++ b/src/names/encoding.h
@@ -39,7 +39,7 @@ NameEncoding ConfiguredValueEncoding ();
 
 /* The options defaults for the encodings.  */
 static constexpr NameEncoding DEFAULT_NAME_ENCODING = NameEncoding::UTF8;
-static constexpr NameEncoding DEFAULT_VALUE_ENCODING = NameEncoding::ASCII;
+static constexpr NameEncoding DEFAULT_VALUE_ENCODING = NameEncoding::UTF8;
 
 /* Utility functions to convert encodings to/from the enum.  They throw
    std::invalid_argument if the conversion fails.  */


### PR DESCRIPTION
Values encoded as UTF-8 JSON are valid according to the consensus rules, so it makes sense to use UTF-8 as the default encoding for values in name_show and related methods.
    
With this, names and values will be default-encoded in UTF-8, which means that all data that is valid according to consensus rules can actually be represented correctly in those RPC results.

This means that it will allow applications using the RPC interface (like [Democrit](https://github.com/xaya/democrit) or [Xaya X](https://github.com/xaya/xayax)) to retrieve all data, and then decide for themselves how to process it.